### PR TITLE
Add email address format validator

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -47,6 +47,9 @@ Metrics/MethodLength:
   Exclude:
     - 'spec/features/*'
 
+RSpec/ContextWording:
+  Enabled: false
+
 RSpec/ExampleLength:
   Exclude:
     - 'spec/features/*'

--- a/app/models/applicants/personal_detail.rb
+++ b/app/models/applicants/personal_detail.rb
@@ -19,6 +19,10 @@ module Applicants
     validates :passport_number, presence: true
     validates :nationality, presence: true, inclusion: { in: NATIONALITIES }
 
+    validate do |record|
+      EmailFormatValidator.new(record).validate
+    end
+
     def date_of_birth
       date_from_hash
     end

--- a/app/validators/email_format_validator.rb
+++ b/app/validators/email_format_validator.rb
@@ -7,7 +7,7 @@
 # Technical Failures)
 
 class EmailFormatValidator
-  EMAIL_REGEX = /^[a-zA-Z0-9.!#$%&'*+\/=?^_`{|}~\-]+@([^.@][^@\s]+)$/
+  EMAIL_REGEX = /^[a-zA-Z0-9.!#$%&'*+\/=?^_`{|}~-]+@([^.@][^@\s]+)$/
   PART_REGEX = /^(xn-|[a-z0-9]+)(-[a-z0-9]+)*$/i
   TLD_REGEX = /^([a-z]{2,63}|xn--([a-z0-9]+-)*[a-z0-9]+)$/
 

--- a/app/validators/email_format_validator.rb
+++ b/app/validators/email_format_validator.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+# Rules and regex taken from https://github.com/alphagov/notifications-utils/blob/fd3ba3db8cfaf4ad5308aaf5efdcd4e0cf3730e8/notifications_utils/recipients.py
+# which in turn was adapted from https://github.com/JoshData/python-email-validator/blob/primary/email_validator/__init__.py
+# with minor tweaks for SES compatibility (we are a lot stricter with the local
+# part than neccessary, not allowing double quotes or semicolons to prevent SES
+# Technical Failures)
+
+class EmailFormatValidator
+  EMAIL_REGEX = /^[a-zA-Z0-9.!#$%&'*+\/=?^_`{|}~\-]+@([^.@][^@\s]+)$/
+  PART_REGEX = /^(xn-|[a-z0-9]+)(-[a-z0-9]+)*$/i
+  TLD_REGEX = /^([a-z]{2,63}|xn--([a-z0-9]+-)*[a-z0-9]+)$/
+
+  MAX_LENGTH = 320
+  MAX_HOSTNAME_LENGTH = 253
+  MAX_PART_LENGTH = 63
+
+  MIN_PARTS = 2
+
+  def initialize(record)
+    @record = record
+    @email = record.email_address
+  end
+
+  def validate
+    return unless email
+
+    record.errors.add(:email_address, error_message) unless valid?
+  end
+
+private
+
+  attr_reader :record, :email
+
+  def valid?
+    matches_regex? &&
+      length_valid? &&
+      no_consecutive_periods? &&
+      hostname_valid?
+  end
+
+  def matches_regex?
+    EMAIL_REGEX.match?(email)
+  end
+
+  def length_valid?
+    email.length <= MAX_LENGTH
+  end
+
+  def no_consecutive_periods?
+    email.exclude?("..")
+  end
+
+  def hostname_valid?
+    hostname_length_valid? &&
+      parts_length_valid? &&
+      parts_match_regex?
+  end
+
+  def hostname_length_valid?
+    hostname.length <= MAX_HOSTNAME_LENGTH
+  end
+
+  def parts_length_valid?
+    parts.length >= MIN_PARTS &&
+      parts.all? { |part| part.length <= MAX_PART_LENGTH }
+  end
+
+  def parts_match_regex?
+    parts.all? { |part| PART_REGEX.match?(part) } &&
+      TLD_REGEX.match?(parts[-1])
+  end
+
+  def hostname
+    @hostname ||= EMAIL_REGEX.match(email)[1]
+  end
+
+  def parts
+    @parts ||= hostname.split(".")
+  end
+
+  def error_message
+    I18n.t("activemodel.errors.models.applicants/personal_detail.attributes.email_address.invalid")
+  end
+end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -85,6 +85,7 @@ en:
               blank: Enter your family name(s)
             email_address:
               blank: Enter your email address
+              invalid: Enter an email address in the correct format, like name@example.com
             phone_number:
               blank: Enter your phone number
             date_of_birth:

--- a/spec/validators/email_format_validator_spec.rb
+++ b/spec/validators/email_format_validator_spec.rb
@@ -1,0 +1,89 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe EmailFormatValidator do
+  subject { Applicants::PersonalDetail.new }
+
+  before { subject.email_address = email }
+
+  context "with a valid email" do
+    let(:email) { "valid@example.com" }
+
+    it "does not add an error" do
+      expect(subject.errors[:email_address]).to be_blank
+    end
+  end
+
+  context "with an invalid email" do
+    error_test = "error test"
+
+    shared_examples_for error_test do
+      it "adds an error" do
+        expect(subject).not_to be_valid
+        expect(subject.errors[:email_address]).not_to be_blank
+      end
+    end
+
+    context "that is only @" do
+      let(:email) { "@" }
+
+      include_examples error_test
+    end
+
+    context "that doesn't contain @" do
+      let(:email) { "invalid" }
+
+      include_examples error_test
+    end
+
+    context "that doesn't match the email regex" do
+      let(:email) { "invalid@b" }
+
+      include_examples error_test
+    end
+
+    context "that is too long" do
+      let(:email) { "#{SecureRandom.alphanumeric(321)}@example.com" }
+
+      include_examples error_test
+    end
+
+    context "that has two consecutive periods" do
+      let(:email) { "invalid..@example.com" }
+
+      include_examples error_test
+    end
+
+    context "that has a hostname that is too long" do
+      valid_part = SecureRandom.alphanumeric(63)
+      let(:email) { "invalid@#{Array.new(4, valid_part).join('.')}.com" }
+
+      include_examples error_test
+    end
+
+    context "that has a hostname with fewer than two parts" do
+      let(:email) { "invalid@example" }
+
+      include_examples error_test
+    end
+
+    context "that has a hostname with a part that is too long" do
+      let(:email) { "invalid@#{SecureRandom.alphanumeric(64)}.com" }
+
+      include_examples error_test
+    end
+
+    context "that has a hostname with a part that doesn't match the regex" do
+      let(:email) { "invalid@example.#.com" }
+
+      include_examples error_test
+    end
+
+    context "that has a hostname with a final part that doesn't match the TLD regex" do
+      let(:email) { "invalid@example.a" }
+
+      include_examples error_test
+    end
+  end
+end

--- a/spec/validators/email_format_validator_spec.rb
+++ b/spec/validators/email_format_validator_spec.rb
@@ -3,15 +3,15 @@
 require "rails_helper"
 
 describe EmailFormatValidator do
-  subject { Applicants::PersonalDetail.new }
+  subject(:applicant) { Applicants::PersonalDetail.new }
 
-  before { subject.email_address = email }
+  before { applicant.email_address = email }
 
   context "with a valid email" do
     let(:email) { "valid@example.com" }
 
     it "does not add an error" do
-      expect(subject.errors[:email_address]).to be_blank
+      expect(applicant.errors[:email_address]).to be_blank
     end
   end
 
@@ -20,8 +20,9 @@ describe EmailFormatValidator do
 
     shared_examples_for error_test do
       it "adds an error" do
-        expect(subject).not_to be_valid
-        expect(subject.errors[:email_address]).not_to be_blank
+        applicant.valid?
+
+        expect(applicant.errors[:email_address]).not_to be_blank
       end
     end
 


### PR DESCRIPTION
**Context**

The email address field on the personal details page was only validated for presence. We now want to ensure that the format the email entered 'looks like' a real email.

**Changes**
- Add new custom  validator class `EmailFormatValidator` which uses rules set out in https://github.com/alphagov/notifications-utils/blob/fd3ba3db8cfaf4ad5308aaf5efdcd4e0cf3730e8/notifications_utils/recipients.py
  - See code comment for more information
- Use this new formatter in the `Applicants::PersonalDetail` model.
- Add error message to translations file

**Guidance for review**
- Enter an incorrect email and check that it errors

Some examples:

Invalid:

<img width="694" alt="Screenshot 2023-05-25 at 11 01 20" src="https://github.com/DFE-Digital/international-teacher-relocation-payment/assets/18436946/e47e1c59-5b71-444d-b2b6-6a05e1709c0e">
<img width="674" alt="Screenshot 2023-05-25 at 11 01 12" src="https://github.com/DFE-Digital/international-teacher-relocation-payment/assets/18436946/51e33af4-b6a0-45f0-a204-4668bcdc04ee">
<img width="681" alt="Screenshot 2023-05-25 at 11 01 42" src="https://github.com/DFE-Digital/international-teacher-relocation-payment/assets/18436946/a9f6756a-cdb2-4318-a060-de8b2df9de4d">

Valid:

<img width="676" alt="Screenshot 2023-05-25 at 11 01 30" src="https://github.com/DFE-Digital/international-teacher-relocation-payment/assets/18436946/7c8c08b2-ff3f-4cc1-a934-a5be49c8300e">
<img width="663" alt="Screenshot 2023-05-25 at 11 02 00" src="https://github.com/DFE-Digital/international-teacher-relocation-payment/assets/18436946/beabb69a-2a9f-4421-87fb-29aa2636b7e5">

Error summary:

<img width="696" alt="Screenshot 2023-05-25 at 11 05 16" src="https://github.com/DFE-Digital/international-teacher-relocation-payment/assets/18436946/1e165c0d-ab14-4c1a-b360-45522264a638">
