### PR TITLE
add basic http auth for system admin (temporary)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+ADMIN_USERNAME=admin
+ADMIN_PASSWORD=password

--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@
 /yarn-error.log
 yarn-debug.log*
 .yarn-integrity
+.env

--- a/app/controllers/system_admin/applicants_controller.rb
+++ b/app/controllers/system_admin/applicants_controller.rb
@@ -3,6 +3,8 @@
 # TODO: Policy to allow only signed in admins to access anything in this module.
 module SystemAdmin
   class ApplicantsController < ApplicationController
+    http_basic_authenticate_with name: ENV.fetch('ADMIN_USERNAME'), password: ENV.fetch('ADMIN_PASSWORD')
+
     before_action :find_applicant, only: %i[show edit update]
     
     def index


### PR DESCRIPTION
## Description

Since the app will deployed to Heroku and it will be publicly available, we should add, at a bare minimum, some form of basic Authentication.

This adds basic HTTP authentication to the whole app ( since at the moment doesn't matter if you access the backend or frontend, it should all be behind authentication )

## Trello Board Link
https://trello.com/c/xEwS0GDo