### PR TITLE
Enable .env for environments out of Git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,4 +30,6 @@
 /yarn-error.log
 yarn-debug.log*
 .yarn-integrity
-.env
+
+!.env.example
+.env*


### PR DESCRIPTION
### What

Enables developers for having on their local environments `env` files per
environment. For example, .env.development, or .env.staging
