### PR TITLE
Extend system tests for trainee route

### DIFF
--- a/spec/features/teacher_route_completing_the_form_spec.rb
+++ b/spec/features/teacher_route_completing_the_form_spec.rb
@@ -18,8 +18,8 @@ describe "teacher route: completing the form" do
       and_i_enter_my_entry_date
       and_i_enter_my_personal_details
       and_i_enter_my_employment_details
-      
-      expect(page).to have_text("hank you for completing the international relocation payment application form")
+
+      expect(page).to have_text("Thank you for completing the international relocation payment application form")
     end
   end
 end

--- a/spec/features/teacher_route_completing_the_form_spec.rb
+++ b/spec/features/teacher_route_completing_the_form_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 
 describe "teacher route: completing the form" do
-  include_context "with application form steps"
+  include_context "with common application form steps"
 
   context "with no eligibility failures" do
     it "submits an application" do

--- a/spec/features/teacher_route_completing_the_form_spec.rb
+++ b/spec/features/teacher_route_completing_the_form_spec.rb
@@ -21,5 +21,21 @@ describe "teacher route: completing the form" do
 
       expect(page).to have_text("Thank you for completing the international relocation payment application form")
     end
+
+    def and_i_complete_the_state_school_question
+      choose_yes
+    end
+
+    def and_i_complete_the_contract_details_question
+      choose_yes
+    end
+
+    def and_i_enter_my_contract_start_date
+      fill_in("Day", with: 12)
+      fill_in("Month", with: 12)
+      fill_in("Year", with: 2020)
+
+      click_button("Continue")
+    end
   end
 end

--- a/spec/features/teacher_route_completing_the_form_spec.rb
+++ b/spec/features/teacher_route_completing_the_form_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-describe "completing the form" do
+describe "teacher route: completing the form" do
   context "with no eligibility failures" do
     it "submits an application" do
       when_i_start_the_form

--- a/spec/features/teacher_route_completing_the_form_spec.rb
+++ b/spec/features/teacher_route_completing_the_form_spec.rb
@@ -3,6 +3,8 @@
 require "rails_helper"
 
 describe "teacher route: completing the form" do
+  include_context "with application form steps"
+
   context "with no eligibility failures" do
     it "submits an application" do
       when_i_start_the_form
@@ -17,77 +19,6 @@ describe "teacher route: completing the form" do
       and_i_enter_my_personal_details
       and_i_enter_my_employment_details
       expect(page).to have_text("hank you for completing the international relocation payment application form")
-    end
-
-    def when_i_start_the_form
-      visit(root_path)
-      click_link("Start")
-    end
-
-    def and_i_complete_application_route_question
-      choose(option: "teacher")
-      click_button("Continue")
-    end
-
-    def and_i_complete_the_state_school_question
-      choose_yes
-    end
-
-    def and_i_complete_the_contract_details_question
-      choose_yes
-    end
-
-    def and_i_enter_my_contract_start_date
-      fill_in("Day", with: 12)
-      fill_in("Month", with: 12)
-      fill_in("Year", with: 2020)
-      click_button("Continue")
-    end
-
-    def and_i_select_my_subject
-      choose("Physics")
-      click_button("Continue")
-    end
-
-    def and_i_confirm_my_subject_percentage
-      choose_yes
-    end
-
-    def and_i_select_my_visa_type
-      select("visa_1")
-      click_button("Continue")
-    end
-
-    def and_i_enter_my_entry_date
-      fill_in("Day", with: 12)
-      fill_in("Month", with: 9)
-      fill_in("Year", with: 2020)
-      click_button("Continue")
-    end
-
-    def and_i_enter_my_personal_details
-      fill_in("applicants_personal_detail[given_name]", with: "Bob")
-      fill_in("applicants_personal_detail[family_name]", with: "Robertson")
-      fill_in("applicants_personal_detail[email_address]", with: "test@example.com")
-      fill_in("applicants_personal_detail[phone_number]", with: "01234567890")
-      fill_in("Day", with: 1)
-      fill_in("Month", with: 1)
-      fill_in("Year", with: 1990)
-      select("English")
-      choose("Male")
-      fill_in("applicants_personal_detail[passport_number]", with: "000")
-      click_button("Continue")
-    end
-
-    def and_i_enter_my_employment_details
-      fill_in("applicants_employment_detail[school_name]", with: "School name")
-      fill_in("applicants_employment_detail[school_headteacher_name]", with: "Ms Headteacher")
-      click_button("Submit application")
-    end
-
-    def choose_yes
-      choose("Yes")
-      click_button("Continue")
     end
   end
 end

--- a/spec/features/teacher_route_completing_the_form_spec.rb
+++ b/spec/features/teacher_route_completing_the_form_spec.rb
@@ -18,6 +18,7 @@ describe "teacher route: completing the form" do
       and_i_enter_my_entry_date
       and_i_enter_my_personal_details
       and_i_enter_my_employment_details
+      
       expect(page).to have_text("hank you for completing the international relocation payment application form")
     end
   end

--- a/spec/features/trainee_route_completing_the_form_spec.rb
+++ b/spec/features/trainee_route_completing_the_form_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 
 describe "trainee route: completing the form" do
-  include_context "with application form steps"
+  include_context "with common application form steps"
 
   context "with no eligibility failures" do
     it "submits an application" do

--- a/spec/features/trainee_route_completing_the_form_spec.rb
+++ b/spec/features/trainee_route_completing_the_form_spec.rb
@@ -2,16 +2,14 @@
 
 require "rails_helper"
 
-describe "teacher route: completing the form" do
+describe "trainee route: completing the form" do
   include_context "with application form steps"
 
   context "with no eligibility failures" do
     it "submits an application" do
       when_i_start_the_form
-      and_i_complete_application_route_question_with(option: "teacher")
-      and_i_complete_the_state_school_question
-      and_i_complete_the_contract_details_question
-      and_i_enter_my_contract_start_date
+      and_i_complete_application_route_question_with(option: "salaried_trainee")
+      and_i_complete_the_trainee_employment_conditions
       and_i_select_my_subject
       and_i_confirm_my_subject_percentage
       and_i_select_my_visa_type
@@ -20,6 +18,14 @@ describe "teacher route: completing the form" do
       and_i_enter_my_employment_details
 
       expect(page).to have_text("Thank you for completing the international relocation payment application form")
+    end
+
+    def and_i_complete_the_trainee_employment_conditions
+      choose_yes
+    end
+
+    def and_i_complete_the_trainee_contract_details_question
+      choose_yes
     end
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -7,6 +7,8 @@ require_relative "../config/environment"
 # Prevent database truncation if the environment is production
 abort("The Rails environment is running in production mode!") if Rails.env.production?
 require "rspec/rails"
+Dir[Rails.root.join("spec/support/**/*.rb")].each { |file| require file }
+
 # Add additional requires below this line. Rails is not loaded until this point!
 
 # Requires supporting ruby files with custom matchers and macros, etc, in

--- a/spec/support/application_form_steps.rb
+++ b/spec/support/application_form_steps.rb
@@ -1,11 +1,13 @@
 RSpec.shared_context "with application form steps" do
   def when_i_start_the_form
     visit(root_path)
+
     click_link("Start")
   end
 
   def and_i_complete_application_route_question
     choose(option: "teacher")
+
     click_button("Continue")
   end
 
@@ -21,11 +23,13 @@ RSpec.shared_context "with application form steps" do
     fill_in("Day", with: 12)
     fill_in("Month", with: 12)
     fill_in("Year", with: 2020)
+
     click_button("Continue")
   end
 
   def and_i_select_my_subject
     choose("Physics")
+
     click_button("Continue")
   end
 
@@ -35,6 +39,7 @@ RSpec.shared_context "with application form steps" do
 
   def and_i_select_my_visa_type
     select("visa_1")
+
     click_button("Continue")
   end
 
@@ -42,6 +47,7 @@ RSpec.shared_context "with application form steps" do
     fill_in("Day", with: 12)
     fill_in("Month", with: 9)
     fill_in("Year", with: 2020)
+
     click_button("Continue")
   end
 
@@ -56,17 +62,20 @@ RSpec.shared_context "with application form steps" do
     select("English")
     choose("Male")
     fill_in("applicants_personal_detail[passport_number]", with: "000")
+
     click_button("Continue")
   end
 
   def and_i_enter_my_employment_details
     fill_in("applicants_employment_detail[school_name]", with: "School name")
     fill_in("applicants_employment_detail[school_headteacher_name]", with: "Ms Headteacher")
+
     click_button("Submit application")
   end
 
   def choose_yes
     choose("Yes")
+
     click_button("Continue")
   end
 end

--- a/spec/support/application_form_steps.rb
+++ b/spec/support/application_form_steps.rb
@@ -13,22 +13,6 @@ RSpec.shared_context "with application form steps" do
     click_button("Continue")
   end
 
-  def and_i_complete_the_state_school_question
-    choose_yes
-  end
-
-  def and_i_complete_the_contract_details_question
-    choose_yes
-  end
-
-  def and_i_enter_my_contract_start_date
-    fill_in("Day", with: 12)
-    fill_in("Month", with: 12)
-    fill_in("Year", with: 2020)
-
-    click_button("Continue")
-  end
-
   def and_i_select_my_subject
     choose("Physics")
 

--- a/spec/support/application_form_steps.rb
+++ b/spec/support/application_form_steps.rb
@@ -1,0 +1,72 @@
+RSpec.shared_context "with application form steps" do
+  def when_i_start_the_form
+    visit(root_path)
+    click_link("Start")
+  end
+
+  def and_i_complete_application_route_question
+    choose(option: "teacher")
+    click_button("Continue")
+  end
+
+  def and_i_complete_the_state_school_question
+    choose_yes
+  end
+
+  def and_i_complete_the_contract_details_question
+    choose_yes
+  end
+
+  def and_i_enter_my_contract_start_date
+    fill_in("Day", with: 12)
+    fill_in("Month", with: 12)
+    fill_in("Year", with: 2020)
+    click_button("Continue")
+  end
+
+  def and_i_select_my_subject
+    choose("Physics")
+    click_button("Continue")
+  end
+
+  def and_i_confirm_my_subject_percentage
+    choose_yes
+  end
+
+  def and_i_select_my_visa_type
+    select("visa_1")
+    click_button("Continue")
+  end
+
+  def and_i_enter_my_entry_date
+    fill_in("Day", with: 12)
+    fill_in("Month", with: 9)
+    fill_in("Year", with: 2020)
+    click_button("Continue")
+  end
+
+  def and_i_enter_my_personal_details
+    fill_in("applicants_personal_detail[given_name]", with: "Bob")
+    fill_in("applicants_personal_detail[family_name]", with: "Robertson")
+    fill_in("applicants_personal_detail[email_address]", with: "test@example.com")
+    fill_in("applicants_personal_detail[phone_number]", with: "01234567890")
+    fill_in("Day", with: 1)
+    fill_in("Month", with: 1)
+    fill_in("Year", with: 1990)
+    select("English")
+    choose("Male")
+    fill_in("applicants_personal_detail[passport_number]", with: "000")
+    click_button("Continue")
+  end
+
+  def and_i_enter_my_employment_details
+    fill_in("applicants_employment_detail[school_name]", with: "School name")
+    fill_in("applicants_employment_detail[school_headteacher_name]", with: "Ms Headteacher")
+    click_button("Submit application")
+  end
+
+  def choose_yes
+    choose("Yes")
+    click_button("Continue")
+  end
+end

--- a/spec/support/application_form_steps.rb
+++ b/spec/support/application_form_steps.rb
@@ -5,8 +5,10 @@ RSpec.shared_context "with application form steps" do
     click_link("Start")
   end
 
-  def and_i_complete_application_route_question
-    choose(option: "teacher")
+  def and_i_complete_application_route_question_with(option:)
+    raise "Unexpected option: #{option}" unless %w[salaried_trainee teacher].include?(option)
+
+    choose(option:)
 
     click_button("Continue")
   end

--- a/spec/support/application_form_steps.rb
+++ b/spec/support/application_form_steps.rb
@@ -1,4 +1,6 @@
-RSpec.shared_context "with application form steps" do
+# frozen_string_literal: true
+
+RSpec.shared_context "with common application form steps" do
   def when_i_start_the_form
     visit(root_path)
 


### PR DESCRIPTION
[Trello card](https://trello.com/c/e8nGGnsH/18-add-system-test-for-the-trainee-route)

### What

Extends system tests for the Trainee route. The current state only covers the Teacher route, 
and although it is good enough for an MVP, it won't allow us to properly evolve it.

I have taken the following actions:

1. Rename the existing system test to clarify the journey that it is covering
2. Add a new system test for the Trainee route (`trainee_route_completing_the_form_spec.rb`)
3. Extract common steps for both tests into a common file

from:
```bash
spec/features/
└── completing_the_form_spec.rb

0 directories, 1 file
```

to:
``` bash
spec/features/
├── teacher_route_completing_the_form_spec.rb
└── trainee_route_completing_the_form_spec.rb

0 directories, 2 files
```

### Pending

1. On the current steps we are not asserting that the user is on the right question, as we are just
selecting `Yes` and moving forward. 
2. The tests are not covering non-happy paths, like dropping out of the journey

On next PRs I will be addressing both issues.