### PR TITLE
Fix typo on Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -29,7 +29,7 @@ gem "config", "~> 4.1"
 gem "httparty", "~> 0.21"
 
 group :test do
-  gem "shoulda-matchers," "~> 5.0"
+  gem "shoulda-matchers", "~> 5.0"
   gem "simplecov", require: false
 end
 


### PR DESCRIPTION
## Description

We are getting this error:

```bash
[!] There was an error parsing `Gemfile`: 'shoulda-matchers,~> 5.0' is not a valid gem name because it contains whitespace. Bundler cannot continue.

 #  from /Users/pmanrubia/work/dfe/international-teacher-relocation-payment/Gemfile:32
 #  -------------------------------------------
 #  group :test do
 >    gem "shoulda-matchers," "~> 5.0"
 #    gem "simplecov", require: false
 #  -------------------------------------------
```

For some reason, this was not picked by our CI. I probably merged it too quickly.

After merging, the `bundle install` works correctly

 