### PR TITLE
Update domain according to adr 0001

### DIFF
--- a/app/models/applicant.rb
+++ b/app/models/applicant.rb
@@ -4,6 +4,8 @@ class Applicant < ApplicationRecord
   # TODO: Add validations here so that a final check is made on the validity of
   # the whole application.
 
+  has_one :applicant_progress, dependent: :destroy
+
   def full_name
     "#{given_name} #{family_name}"
   end

--- a/app/models/applicant.rb
+++ b/app/models/applicant.rb
@@ -6,6 +6,14 @@ class Applicant < ApplicationRecord
 
   has_one :applicant_progress, dependent: :destroy
 
+  delegate \
+    :initial_checks_completed_at,
+    :visa_investigation_required,
+    :home_office_checks_completed_at,
+    :school_investigation_required,
+    :school_checks_completed_at,
+    :application_route, to: :applicant_progress
+
   def full_name
     "#{given_name} #{family_name}"
   end

--- a/app/models/applicant_progress.rb
+++ b/app/models/applicant_progress.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class ApplicantProgress < ApplicationRecord
+  belongs_to :applicant
+end

--- a/db/migrate/20230602115745_create_applicant_progresses.rb
+++ b/db/migrate/20230602115745_create_applicant_progresses.rb
@@ -1,0 +1,14 @@
+class CreateApplicantProgresses < ActiveRecord::Migration[7.0]
+  def change
+    create_table :applicant_progresses do |t|
+      t.references :applicant, null: false, foreign_key: true
+      t.date :initial_checks_completed_at
+      t.boolean :visa_investigation_required
+      t.date :home_office_checks_completed_at
+      t.boolean :school_investigation_required
+      t.date :school_checks_completed_at
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20230602121235_remove_columns_from_applicants.rb
+++ b/db/migrate/20230602121235_remove_columns_from_applicants.rb
@@ -1,0 +1,11 @@
+class RemoveColumnsFromApplicants < ActiveRecord::Migration[7.0]
+  def change
+    change_table :applicants, bulk: true do |t|
+      t.remove :initial_checks_completed_at
+      t.remove :visa_investigation_required
+      t.remove :home_office_checks_completed_at
+      t.remove :school_investigation_required
+      t.remove :school_checks_completed_at
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_06_02_115745) do
+ActiveRecord::Schema[7.0].define(version: 2023_06_02_121235) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -42,11 +42,6 @@ ActiveRecord::Schema[7.0].define(version: 2023_06_02_115745) do
     t.date "date_of_entry"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.date "initial_checks_completed_at"
-    t.boolean "visa_investigation_required"
-    t.date "home_office_checks_completed_at"
-    t.boolean "school_investigation_required"
-    t.date "school_checks_completed_at"
     t.string "application_route"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,21 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_05_25_152425) do
+ActiveRecord::Schema[7.0].define(version: 2023_06_02_115745) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "applicant_progresses", force: :cascade do |t|
+    t.bigint "applicant_id", null: false
+    t.date "initial_checks_completed_at"
+    t.boolean "visa_investigation_required"
+    t.date "home_office_checks_completed_at"
+    t.boolean "school_investigation_required"
+    t.date "school_checks_completed_at"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["applicant_id"], name: "index_applicant_progresses_on_applicant_id"
+  end
 
   create_table "applicants", force: :cascade do |t|
     t.text "given_name"


### PR DESCRIPTION
https://trello.com/c/1FnvCM54/43-update-domain-model-to-include-progress-and-applicant

## Description

Following the [work on the ADR to describe the initial model](https://github.com/DFE-Digital/international-teacher-relocation-payment/pull/11), I am extracting 
the progress domain class that will hold information related to checks and validations.

```ruby
  create_table "applicant_progresses", force: :cascade do |t|
    t.bigint "applicant_id", null: false
    t.date "initial_checks_completed_at"
    t.boolean "visa_investigation_required"
    t.date "home_office_checks_completed_at"
    t.boolean "school_investigation_required"
    t.date "school_checks_completed_at"
    t.datetime "created_at", null: false
    t.datetime "updated_at", null: false
    t.index ["applicant_id"], name: "index_applicant_progresses_on_applicant_id"
  end
```

## Tech notes

We don't have valuable data on those fields (the ones I have extracted), hence there is 
no need to migrate anything. The fields were used for demo purposes.

On the other side, we don't have users, so it is not a risk to create new tables and delete 
columns.

### Next

* I am using `delegate` from Application to ApplicationProgress. We probably need to review which one is the root entity and change the direction of the association.


