### PR TITLE
Apply missing rubocop changes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -40,18 +40,17 @@ group :development, :test do
   gem "rubocop-rspec"
 
   # Debugging
-  gem "pry-byebug"
   gem "debug", platforms: %i[mri mingw x64_mingw]
-
+  gem "pry-byebug"
 
   # Better use of test helpers such as save_and_open_page/screenshot
   gem "launchy"
   gem "pry-byebug"
   # Testing framework
-  gem "capybara"
-  gem "dotenv-rails"
   gem "brakeman"
   gem "bundler-audit"
+  gem "capybara"
+  gem "dotenv-rails"
   gem "rspec-rails"
 end
 

--- a/app/controllers/system_admin/applicants_controller.rb
+++ b/app/controllers/system_admin/applicants_controller.rb
@@ -3,7 +3,7 @@
 # TODO: Policy to allow only signed in admins to access anything in this module.
 module SystemAdmin
   class ApplicantsController < ApplicationController
-    http_basic_authenticate_with name: ENV.fetch('ADMIN_USERNAME'), password: ENV.fetch('ADMIN_PASSWORD')
+    http_basic_authenticate_with name: ENV.fetch("ADMIN_USERNAME"), password: ENV.fetch("ADMIN_PASSWORD")
 
     before_action :find_applicant, only: %i[show edit update]
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
-require 'simplecov'
-SimpleCov.start('rails') do
+
+require "simplecov"
+SimpleCov.start("rails") do
   enable_coverage :branch
 end
 


### PR DESCRIPTION
## Description

Apply multiple `Rubocop` fixes:

-  Bundler/OrderedGems:
- Layout/EmptyLines
-  Style/StringLiterals
 
```bash
Offenses:

Gemfile:44:3: C: [Corrected] Bundler/OrderedGems: Gems should be sorted in an alphabetical order within their section of the Gemfile. Gem debug should appear before pry-byebug.
Gemfile:46:1: C: [Corrected] Layout/EmptyLines: Extra blank line detected. (https://rubystyle.guide#two-or-more-empty-lines)
Gemfile:48:3: W: Bundler/DuplicatedGem: Gem pry-byebug requirements already given on line 44 of the Gemfile.
Gemfile:51:3: C: [Corrected] Bundler/OrderedGems: Gems should be sorted in an alphabetical order within their section of the Gemfile. Gem brakeman should appear before capybara.
Gemfile:52:3: C: [Corrected] Bundler/OrderedGems: Gems should be sorted in an alphabetical order within their section of the Gemfile. Gem bundler-audit should appear before capybara.
Gemfile:53:3: C: [Corrected] Bundler/OrderedGems: Gems should be sorted in an alphabetical order within their section of the Gemfile. Gem brakeman should appear before dotenv-rails.
Gemfile:53:3: C: [Corrected] Bundler/OrderedGems: Gems should be sorted in an alphabetical order within their section of the Gemfile. Gem bundler-audit should appear before dotenv-rails.
app/controllers/system_admin/applicants_controller.rb:6:50: C: [Corrected] Style/StringLiterals: Prefer double-quoted strings unless you need single quotes to avoid extra backslashes for escaping. (https://rubystyle.guide#consistent-string-literals)
app/controllers/system_admin/applicants_controller.rb:6:89: C: [Corrected] Style/StringLiterals: Prefer double-quoted strings unless you need single quotes to avoid extra backslashes for escaping. (https://rubystyle.guide#consistent-string-literals)
spec/rails_helper.rb:2:1: C: [Corrected] Layout/EmptyLineAfterMagicComment: Add an empty line after magic comments. (https://rubystyle.guide#separate-magic-comments-from-code)
spec/rails_helper.rb:2:9: C: [Corrected] Style/StringLiterals: Prefer double-quoted strings unless you need single quotes to avoid extra backslashes for escaping. (https://rubystyle.guide#consistent-string-literals)
spec/rails_helper.rb:3:17: C: [Corrected] Style/StringLiterals: Prefer double-quoted strings unless you need single quotes to avoid extra backslashes for escaping. (https://rubystyle.guide#consistent-string-literals)
```