### PR TITLE
Add lint fixes for CI

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -39,6 +39,10 @@ Lint/AmbiguousBlockAssociation:
   Exclude:
     - 'spec/**/*'
 
+Rails/BulkChangeTable:
+  Exclude:
+    - 'db/migrate/**/*.rb'
+
 Metrics/MethodLength:
   Exclude:
     - 'spec/features/*'

--- a/Gemfile
+++ b/Gemfile
@@ -45,7 +45,7 @@ group :development, :test do
 
   # Better use of test helpers such as save_and_open_page/screenshot
   gem "launchy"
-  gem "pry-byebug"
+
   # Testing framework
   gem "brakeman"
   gem "bundler-audit"

--- a/db/migrate/20230602121235_remove_columns_from_applicants.rb
+++ b/db/migrate/20230602121235_remove_columns_from_applicants.rb
@@ -1,11 +1,9 @@
 class RemoveColumnsFromApplicants < ActiveRecord::Migration[7.0]
   def change
-    change_table :applicants, bulk: true do |t|
-      t.remove :initial_checks_completed_at
-      t.remove :visa_investigation_required
-      t.remove :home_office_checks_completed_at
-      t.remove :school_investigation_required
-      t.remove :school_checks_completed_at
-    end
+    remove_column :applicants, :initial_checks_completed_at, :date
+    remove_column :applicants, :visa_investigation_required, :boolean
+    remove_column :applicants, :home_office_checks_completed_at, :date
+    remove_column :applicants, :school_investigation_required, :boolean
+    remove_column :applicants, :school_checks_completed_at, :date
   end
 end


### PR DESCRIPTION
## Description

Make our Lint happier by:

1. Ignoring rule BulkChangeTable via Rubocop
2. Remove duplicated gem definition

As a side goal [we are making a migration reversible](c9efd8a35bdc04b386fc5f7d0e5b1bfe6e5570ca).