### PR TITLE
update setup ruby to use v1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,8 +58,9 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
       - name: Install Ruby and gems
-        uses: ruby/setup-ruby@55283cc23133118229fd3f97f9336ee23a179fcf # v1.146.0
+        uses: ruby/setup-ruby@v1
         with:
+          ruby-version: 3.1.3
           bundler-cache: true
       # Add or replace any other lints here
       - name: Security audit dependencies


### PR DESCRIPTION
## Description
Update the setup-ruby version to use the v1 on the Lint action just the same
as is done on the Rspec action.

So we can avoid dependabot making new pullrequest for each minor version