### PR TITLE
Add date validator

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -35,6 +35,14 @@ Style/HashSyntax:
 Style/Documentation:
   Enabled: false
 
+Lint/ConstantDefinitionInBlock:
+  Exclude:
+    - 'spec/**/*'
+
+RSpec/LeakyConstantDeclaration:
+  Exclude:
+    - 'spec/**/*'
+
 Lint/AmbiguousBlockAssociation:
   Exclude:
     - 'spec/**/*'

--- a/app/controllers/applicants/contract_start_dates_controller.rb
+++ b/app/controllers/applicants/contract_start_dates_controller.rb
@@ -4,12 +4,6 @@ module Applicants
   class ContractStartDatesController < ApplicationController
     before_action :check_teacher!
 
-    DATE_CONVERSION = {
-      "contract_start_date(3i)" => "day",
-      "contract_start_date(2i)" => "month",
-      "contract_start_date(1i)" => "year",
-    }.freeze
-
     def new
       @contract_start_date = ContractStartDate.new
     end
@@ -33,5 +27,12 @@ module Applicants
         *DATE_CONVERSION.keys,
       ).transform_keys { |key| DATE_CONVERSION[key] }
     end
+
+    DATE_CONVERSION = {
+      "contract_start_date(3i)" => "day",
+      "contract_start_date(2i)" => "month",
+      "contract_start_date(1i)" => "year",
+    }.freeze
+    private_constant :DATE_CONVERSION
   end
 end

--- a/app/models/applicants/contract_start_date.rb
+++ b/app/models/applicants/contract_start_date.rb
@@ -3,17 +3,18 @@
 module Applicants
   class ContractStartDate
     include ActiveModel::Model
-    include DateHelpers
     attr_accessor :day, :month, :year
+
+    validate do |record|
+      DayMonthYearDateValidator.new.validate(record)
+    end
 
     validates :contract_start_date, presence: true
 
     def contract_start_date
-      date_from_hash
-    end
-
-    validate do |record|
-      DayMonthYearDateValidator.new.validate(record)
+      Date.new(year.to_i, month.to_i, day.to_i)
+    rescue StandardError
+      nil
     end
   end
 end

--- a/app/models/applicants/contract_start_date.rb
+++ b/app/models/applicants/contract_start_date.rb
@@ -11,5 +11,9 @@ module Applicants
     def contract_start_date
       date_from_hash
     end
+
+    validate do |record|
+      DayMonthYearDateValidator.new.validate(record)
+    end
   end
 end

--- a/app/models/applicants/contract_start_date.rb
+++ b/app/models/applicants/contract_start_date.rb
@@ -14,7 +14,13 @@ module Applicants
     def contract_start_date
       Date.new(year.to_i, month.to_i, day.to_i)
     rescue StandardError
-      nil
+      InvalidDate.new(day:, month:, year:)
+    end
+
+    InvalidDate = Struct.new(:day, :month, :year, keyword_init: true) do
+      def blank?
+        members.all? { |date_field| public_send(date_field).blank? }
+      end
     end
   end
 end

--- a/app/validators/day_month_year_date_validator.rb
+++ b/app/validators/day_month_year_date_validator.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+class DayMonthYearDateValidator
+  def validate(record, attribute = "day_month_year_date")
+    @record = record
+
+    record.errors.add(attribute, "is not a valid date") unless valid?
+  end
+
+private
+
+  def valid?
+    day = @record.day
+    month = @record.month
+    year = @record.year
+
+    return false unless day.present? && month.present? && year.present?
+
+    Date.valid_date?(year, month, day)
+  rescue ArgumentError
+    false
+  end
+end

--- a/app/validators/day_month_year_date_validator.rb
+++ b/app/validators/day_month_year_date_validator.rb
@@ -10,13 +10,14 @@ class DayMonthYearDateValidator
 private
 
   def valid?
-    day = @record.day
-    month = @record.month
-    year = @record.year
+    day = @record.day.to_i
+    month = @record.month.to_i
+    year = @record.year.to_i
 
     return false unless day.present? && month.present? && year.present?
+    return false unless [day, month, year].all?(&:positive?)
 
-    Date.valid_date?(year.to_i, month.to_i, day.to_i)
+    Date.valid_date?(year, month, day)
   rescue ArgumentError
     false
   end

--- a/app/validators/day_month_year_date_validator.rb
+++ b/app/validators/day_month_year_date_validator.rb
@@ -16,7 +16,7 @@ private
 
     return false unless day.present? && month.present? && year.present?
 
-    Date.valid_date?(year, month, day)
+    Date.valid_date?(year.to_i, month.to_i, day.to_i)
   rescue ArgumentError
     false
   end

--- a/app/validators/day_month_year_date_validator.rb
+++ b/app/validators/day_month_year_date_validator.rb
@@ -10,11 +10,12 @@ class DayMonthYearDateValidator
 private
 
   def valid?
+    return true unless @record.day.present? && @record.month.present? && @record.year.present?
+
     day = @record.day.to_i
     month = @record.month.to_i
     year = @record.year.to_i
 
-    return false unless day.present? && month.present? && year.present?
     return false unless [day, month, year].all?(&:positive?)
 
     Date.valid_date?(year, month, day)

--- a/app/validators/day_month_year_date_validator.rb
+++ b/app/validators/day_month_year_date_validator.rb
@@ -4,7 +4,7 @@ class DayMonthYearDateValidator
   def validate(record, attribute = "day_month_year_date")
     @record = record
 
-    record.errors.add(attribute, "is not a valid date") unless valid?
+    record.errors.add(attribute, "Enter a valid date") unless valid?
   end
 
 private

--- a/spec/features/teacher_route_completing_the_form_spec.rb
+++ b/spec/features/teacher_route_completing_the_form_spec.rb
@@ -23,6 +23,26 @@ describe "teacher route: completing the form" do
     end
   end
 
+  context "with validation errors" do
+    it "does not allow the user to continue the journey" do
+      when_i_start_the_form
+      and_i_complete_application_route_question_with(option: "teacher")
+      and_i_complete_the_state_school_question
+      and_i_complete_the_contract_details_question
+      and_i_enter_an_invalid_date
+
+      expect(page).to have_text("Enter a valid date")
+    end
+
+    def and_i_enter_an_invalid_date
+      fill_in("Day", with: 31)
+      fill_in("Month", with: 2)
+      fill_in("Year", with: 2019)
+
+      click_button("Continue")
+    end
+  end
+
   def and_i_complete_the_state_school_question
     choose_yes
   end

--- a/spec/features/teacher_route_completing_the_form_spec.rb
+++ b/spec/features/teacher_route_completing_the_form_spec.rb
@@ -21,21 +21,21 @@ describe "teacher route: completing the form" do
 
       expect(page).to have_text("Thank you for completing the international relocation payment application form")
     end
+  end
 
-    def and_i_complete_the_state_school_question
-      choose_yes
-    end
+  def and_i_complete_the_state_school_question
+    choose_yes
+  end
 
-    def and_i_complete_the_contract_details_question
-      choose_yes
-    end
+  def and_i_complete_the_contract_details_question
+    choose_yes
+  end
 
-    def and_i_enter_my_contract_start_date
-      fill_in("Day", with: 12)
-      fill_in("Month", with: 12)
-      fill_in("Year", with: 2020)
+  def and_i_enter_my_contract_start_date
+    fill_in("Day", with: 12)
+    fill_in("Month", with: 12)
+    fill_in("Year", with: 2020)
 
-      click_button("Continue")
-    end
+    click_button("Continue")
   end
 end

--- a/spec/validators/day_month_year_date_validator_spec.rb
+++ b/spec/validators/day_month_year_date_validator_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe DayMonthYearDateValidator do
         validatable.year = 2023
         validatable.valid?
 
-        expect(validatable.errors[:day_month_year_date]).to include("is not a valid date")
+        expect(validatable.errors[:day_month_year_date]).to include("Enter a valid date")
       end
     end
 
@@ -48,21 +48,21 @@ RSpec.describe DayMonthYearDateValidator do
         validatable.day = nil
         validatable.valid?
 
-        expect(validatable.errors[:day_month_year_date]).to include("is not a valid date")
+        expect(validatable.errors[:day_month_year_date]).to include("Enter a valid date")
       end
 
       it "fails validation when missing month" do
         validatable.month = nil
         validatable.valid?
 
-        expect(validatable.errors[:day_month_year_date]).to include("is not a valid date")
+        expect(validatable.errors[:day_month_year_date]).to include("Enter a valid date")
       end
 
       it "fails validation when missing year" do
         validatable.year = nil
         validatable.valid?
 
-        expect(validatable.errors[:day_month_year_date]).to include("is not a valid date")
+        expect(validatable.errors[:day_month_year_date]).to include("Enter a valid date")
       end
     end
   end

--- a/spec/validators/day_month_year_date_validator_spec.rb
+++ b/spec/validators/day_month_year_date_validator_spec.rb
@@ -12,8 +12,9 @@ RSpec.describe DayMonthYearDateValidator do
     end
   end
 
-  let(:valid_attributes) { { day: 15, month: 6, year: 2023 } }
   subject(:validatable) { Validatable.new(valid_attributes) }
+
+  let(:valid_attributes) { { day: "15", month: "6", year: "2023" } }
 
   describe "#validate" do
     context "when the date is valid" do
@@ -26,8 +27,8 @@ RSpec.describe DayMonthYearDateValidator do
 
     context "when the date is invalid" do
       it "fails validation" do
-        validatable.day = 31
-        validatable.month = 2 # Invalid month
+        validatable.day = "31"
+        validatable.month = "2" # Invalid month
         validatable.valid?
 
         expect(validatable.errors[:day_month_year_date]).to include("Enter a valid date")

--- a/spec/validators/day_month_year_date_validator_spec.rb
+++ b/spec/validators/day_month_year_date_validator_spec.rb
@@ -26,8 +26,16 @@ RSpec.describe DayMonthYearDateValidator do
     end
 
     context "when the date is invalid" do
-      it "fails validation" do
+      it "fails validation with non-existing dates" do
         validatable.day = "31"
+        validatable.month = "2" # Invalid month
+        validatable.valid?
+
+        expect(validatable.errors[:day_month_year_date]).to include("Enter a valid date")
+      end
+
+      it "fails validation with negative numbers" do
+        validatable.day = -1
         validatable.month = "2" # Invalid month
         validatable.valid?
 

--- a/spec/validators/day_month_year_date_validator_spec.rb
+++ b/spec/validators/day_month_year_date_validator_spec.rb
@@ -1,0 +1,69 @@
+# spec/validators/day_month_year_date_validator_spec.rb
+
+require "rails_helper"
+
+RSpec.describe DayMonthYearDateValidator do
+  class Validatable
+    include ActiveModel::Model
+    attr_accessor :day, :month, :year
+
+    validate do |record|
+      DayMonthYearDateValidator.new.validate(record)
+    end
+  end
+
+  subject(:validatable) { Validatable.new }
+
+  describe "#validate" do
+    context "when the date is valid" do
+      it "passes validation" do
+        validatable.day = 15
+        validatable.month = 6
+        validatable.year = 2023
+        validatable.valid?
+
+        expect(validatable).to be_valid
+      end
+    end
+
+    context "when the date is invalid" do
+      it "fails validation" do
+        validatable.day = 31
+        validatable.month = 2 # Invalid month
+        validatable.year = 2023
+        validatable.valid?
+
+        expect(validatable.errors[:day_month_year_date]).to include("is not a valid date")
+      end
+    end
+
+    context "when missing fields" do
+      before do
+        validatable.day = 15
+        validatable.month = 6
+        validatable.year = 2023
+      end
+
+      it "fails validation when missing day" do
+        validatable.day = nil
+        validatable.valid?
+
+        expect(validatable.errors[:day_month_year_date]).to include("is not a valid date")
+      end
+
+      it "fails validation when missing month" do
+        validatable.month = nil
+        validatable.valid?
+
+        expect(validatable.errors[:day_month_year_date]).to include("is not a valid date")
+      end
+
+      it "fails validation when missing year" do
+        validatable.year = nil
+        validatable.valid?
+
+        expect(validatable.errors[:day_month_year_date]).to include("is not a valid date")
+      end
+    end
+  end
+end

--- a/spec/validators/day_month_year_date_validator_spec.rb
+++ b/spec/validators/day_month_year_date_validator_spec.rb
@@ -12,14 +12,12 @@ RSpec.describe DayMonthYearDateValidator do
     end
   end
 
-  subject(:validatable) { Validatable.new }
+  let(:valid_attributes) { { day: 15, month: 6, year: 2023 } }
+  subject(:validatable) { Validatable.new(valid_attributes) }
 
   describe "#validate" do
     context "when the date is valid" do
       it "passes validation" do
-        validatable.day = 15
-        validatable.month = 6
-        validatable.year = 2023
         validatable.valid?
 
         expect(validatable).to be_valid
@@ -30,7 +28,6 @@ RSpec.describe DayMonthYearDateValidator do
       it "fails validation" do
         validatable.day = 31
         validatable.month = 2 # Invalid month
-        validatable.year = 2023
         validatable.valid?
 
         expect(validatable.errors[:day_month_year_date]).to include("Enter a valid date")
@@ -38,12 +35,6 @@ RSpec.describe DayMonthYearDateValidator do
     end
 
     context "when missing fields" do
-      before do
-        validatable.day = 15
-        validatable.month = 6
-        validatable.year = 2023
-      end
-
       it "fails validation when missing day" do
         validatable.day = nil
         validatable.valid?

--- a/spec/validators/day_month_year_date_validator_spec.rb
+++ b/spec/validators/day_month_year_date_validator_spec.rb
@@ -44,25 +44,22 @@ RSpec.describe DayMonthYearDateValidator do
     end
 
     context "when missing fields" do
-      it "fails validation when missing day" do
+      it "does not perform validation if day `nil`" do
         validatable.day = nil
-        validatable.valid?
 
-        expect(validatable.errors[:day_month_year_date]).to include("Enter a valid date")
+        expect(validatable).to be_valid
       end
 
-      it "fails validation when missing month" do
+      it "does not perform validation if month `nil`" do
         validatable.month = nil
-        validatable.valid?
 
-        expect(validatable.errors[:day_month_year_date]).to include("Enter a valid date")
+        expect(validatable).to be_valid
       end
 
-      it "fails validation when missing year" do
+      it "does not perform validation if year `nil`" do
         validatable.year = nil
-        validatable.valid?
 
-        expect(validatable.errors[:day_month_year_date]).to include("Enter a valid date")
+        expect(validatable).to be_valid
       end
     end
   end


### PR DESCRIPTION
## Trello Card Link

https://trello.com/c/OUZlpHI0/51-teacher-route-length-of-contract

## Description

Adds a Date validation for users on the Tearcher route when entering the
start of the contract date.

The existing version allows users to not enter any date or not enter a valid one.
On this PR, I am also removing the dependency from `DatesHelper` and creating a
custom validator that is aligned with the rest of the codebase (relies on ActiveModel
and validations)

### Screenshots

**Start of contract is mandatory**

<img width="720" alt="image" src="https://github.com/DFE-Digital/international-teacher-relocation-payment/assets/134513241/4662a5b0-086e-4d06-a982-b7cfaf5fa323">

**Invalid dates are not accepted**
<img width="741" alt="image" src="https://github.com/DFE-Digital/international-teacher-relocation-payment/assets/134513241/fc8c2f24-0d0a-4735-a791-524ac2fb2e47">


