### PR TITLE
Add pending validations for Entry Date question.

### DIFF
--- a/app/controllers/applicants/entry_dates_controller.rb
+++ b/app/controllers/applicants/entry_dates_controller.rb
@@ -2,12 +2,6 @@
 
 module Applicants
   class EntryDatesController < ApplicationController
-    DATE_CONVERSION = {
-      "entry_date(3i)" => "day",
-      "entry_date(2i)" => "month",
-      "entry_date(1i)" => "year",
-    }.freeze
-
     def new
       @entry_date = EntryDate.new
     end
@@ -35,5 +29,12 @@ module Applicants
         *DATE_CONVERSION.keys,
       ).transform_keys { |key| DATE_CONVERSION[key] }
     end
+
+    DATE_CONVERSION = {
+      "entry_date(3i)" => "day",
+      "entry_date(2i)" => "month",
+      "entry_date(1i)" => "year",
+    }.freeze
+    private_constant :DATE_CONVERSION
   end
 end

--- a/app/models/applicants/entry_date.rb
+++ b/app/models/applicants/entry_date.rb
@@ -19,7 +19,7 @@ module Applicants
 
     InvalidDate = Struct.new(:day, :month, :year, keyword_init: true) do
       def blank?
-        members.all? { |date_field| public_send(date_field).blank? }
+        members.any? { |date_field| public_send(date_field).blank? }
       end
     end
 

--- a/app/models/applicants/entry_date.rb
+++ b/app/models/applicants/entry_date.rb
@@ -3,13 +3,24 @@
 module Applicants
   class EntryDate
     include ActiveModel::Model
-    include DateHelpers
     attr_accessor :day, :month, :year
 
     validates :entry_date, presence: true
 
+    validate do |record|
+      DayMonthYearDateValidator.new.validate(record)
+    end
+
     def entry_date
-      date_from_hash
+      Date.new(year.to_i, month.to_i, day.to_i)
+    rescue StandardError
+      InvalidDate.new(day:, month:, year:)
+    end
+
+    InvalidDate = Struct.new(:day, :month, :year, keyword_init: true) do
+      def blank?
+        members.all? { |date_field| public_send(date_field).blank? }
+      end
     end
 
     # If the applicant is a teacher who entered the country more than three

--- a/app/models/applicants/entry_date.rb
+++ b/app/models/applicants/entry_date.rb
@@ -12,6 +12,8 @@ module Applicants
     end
 
     def entry_date
+      return InvalidDate.new(day:, month:, year:) if year.blank?
+
       Date.new(year.to_i, month.to_i, day.to_i)
     rescue StandardError
       InvalidDate.new(day:, month:, year:)

--- a/spec/models/applicants/entry_date_spec.rb
+++ b/spec/models/applicants/entry_date_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module Applicants
+  describe EntryDate do
+    describe "#entry_date" do
+      context "when all date fields are valid" do
+        let(:entry_date) { described_class.new(day: "1", month: "2", year: "2023") }
+
+        it "returns a valid Date object" do
+          expect(entry_date.entry_date).to be_a(Date)
+        end
+
+        it "is valid" do
+          expect(entry_date).to be_valid
+        end
+      end
+
+      context "when the date is invalid" do
+        let(:entry_date) { described_class.new(day: "31", month: "2", year: "2023") }
+
+        it "returns an InvalidDate object" do
+          expect(entry_date.entry_date).to be_a(Applicants::EntryDate::InvalidDate)
+        end
+
+        it "is not valid" do
+          expect(entry_date).not_to be_valid
+        end
+      end
+
+      describe "validations" do
+        it "validates presence of the day of the month" do
+          params = { day: "", month: "2", year: "2023" }
+
+          value = described_class.new(params)
+          expect(value).not_to be_valid
+        end
+
+        it "validates presence of the month" do
+          params = { day: "2", month: "", year: "2023" }
+
+          value = described_class.new(params)
+          expect(value).not_to be_valid
+        end
+      end
+    end
+  end
+end

--- a/spec/models/applicants/entry_date_spec.rb
+++ b/spec/models/applicants/entry_date_spec.rb
@@ -43,6 +43,13 @@ module Applicants
           value = described_class.new(params)
           expect(value).not_to be_valid
         end
+
+        it "validates presence of the year" do
+          params = { day: "2", month: "2", year: "" }
+
+          value = described_class.new(params)
+          expect(value).not_to be_valid
+        end
       end
     end
   end

--- a/spec/models/applicants/entry_date_spec.rb
+++ b/spec/models/applicants/entry_date_spec.rb
@@ -4,51 +4,57 @@ require "rails_helper"
 
 module Applicants
   describe EntryDate do
-    describe "#entry_date" do
-      context "when all date fields are valid" do
-        let(:entry_date) { described_class.new(day: "1", month: "2", year: "2023") }
+    subject(:entry_date) { described_class.new(params) }
 
-        it "returns a valid Date object" do
-          expect(entry_date.entry_date).to be_a(Date)
-        end
+    let(:params) { { day:, month:, year: } }
+    let(:day) { "1" }
+    let(:month) { "2" }
+    let(:year) { "2023" }
 
-        it "is valid" do
-          expect(entry_date).to be_valid
-        end
+    context "when all date fields are valid" do
+      it "returns a valid object" do
+        expect(entry_date).to be_valid
       end
 
-      context "when the date is invalid" do
-        let(:entry_date) { described_class.new(day: "31", month: "2", year: "2023") }
+      it "returns a Date object" do
+        expect(entry_date.entry_date).to be_a(Date)
+      end
+    end
 
-        it "returns an InvalidDate object" do
-          expect(entry_date.entry_date).to be_a(Applicants::EntryDate::InvalidDate)
-        end
+    context "when the date is invalid" do
+      let(:day) { "31" }
+
+      it "is not valid" do
+        expect(entry_date).not_to be_valid
+      end
+
+      it "returns an InvalidDate object" do
+        expect(entry_date.entry_date).to be_a(Applicants::EntryDate::InvalidDate)
+      end
+    end
+
+    describe "validations" do
+      context "when the day of the month is missing" do
+        let(:day) { "" }
 
         it "is not valid" do
           expect(entry_date).not_to be_valid
         end
       end
 
-      describe "validations" do
-        it "validates presence of the day of the month" do
-          params = { day: "", month: "2", year: "2023" }
+      context "when the month is missing" do
+        let(:month) { "" }
 
-          value = described_class.new(params)
-          expect(value).not_to be_valid
+        it "is not valid" do
+          expect(entry_date).not_to be_valid
         end
+      end
 
-        it "validates presence of the month" do
-          params = { day: "2", month: "", year: "2023" }
+      context "when the year is missing" do
+        let(:year) { "" }
 
-          value = described_class.new(params)
-          expect(value).not_to be_valid
-        end
-
-        it "validates presence of the year" do
-          params = { day: "2", month: "2", year: "" }
-
-          value = described_class.new(params)
-          expect(value).not_to be_valid
+        it "is not valid" do
+          expect(entry_date).not_to be_valid
         end
       end
     end


### PR DESCRIPTION
## Trello Card Link

https://trello.com/c/TVJxCZSc/54-teacher-route-date-of-entry

## Description

Adds validation for the `EntryDate` of the users. The validation will 
make sure that all the fields are present and that the date is valid.

## Technical notes

1. I have reused the `DayMonthYearDateValidator` introduced in #31
2. I have introduced [duplication on the validation](https://github.com/DFE-Digital/international-teacher-relocation-payment/commit/cbb6246d556015f958ed2be81029324ac6ba129d); I have not 
extracted out the duplicated code as I would like to have a simple PR so this story 
can be properly tested. But I will proceed next with the refactoring.
3. I have introduced a [fix that prevents `nil` years making a date valid](79f6b23b31c1d085fcfdd02b97166174d7ebe46f). This fix has automatically propagated to the `start contract question`
4. I have introduced a second [fix](2ca2b3d37f435e3cdbe0c9d4f5b5c06d9cc40b63) that will raise a validation error if any of the attributes of the date is `nil`: `day`, `month` or `year`. Again, this has propagated to `start_contract_question`

### Next steps

1. Remove duplication between `start_date_contract` and `entry_date`
2. Unify both questions around dates with a single class that will remove duplication. 
3. Extract Eligibility into a `Policy` class as the question itself should not have business logic embedded. I understand this was implemented this way first to speed up the development.

## Screenshots

<img width="781" alt="image" src="https://github.com/DFE-Digital/international-teacher-relocation-payment/assets/134513241/88d3d536-4bb4-42bf-b01a-112b7ccc6ea9">

<img width="746" alt="image" src="https://github.com/DFE-Digital/international-teacher-relocation-payment/assets/134513241/c18203c9-456b-46d5-bc48-4abf16260f5d">

<img width="738" alt="image" src="https://github.com/DFE-Digital/international-teacher-relocation-payment/assets/134513241/54afcf83-c0a5-4be1-a548-3624c12c0267">



