### PR TITLE
Use GOV.UK convention for hint on 

### DIFF
--- a/app/views/applicants/salaried_course_details/new.html.erb
+++ b/app/views/applicants/salaried_course_details/new.html.erb
@@ -6,8 +6,9 @@
 
       <%= f.govuk_radio_buttons_fieldset(
         :eligible_course,
+        hint: { text: "Check with your training provider if you're not sure. You will still be eligible for the international relocation payment if your course leads to PGCE + QTS or PGDE + QTS." },
         legend: { text: "Are you currently employed in a school as a trainee teacher, on a teacher training course in England which meets the following conditions?", tag: "h1", size: "l" }
-        ) do %>
+      ) do %>
 
         <p class="govuk-body">
           The course must:
@@ -18,12 +19,6 @@
           <li>lead to QTS</li>
           <li>be accredited by the UK government</li>
         </ul>
-
-        <p class="govuk-body">
-          Check with your training provider if you're not sure. You will still
-          be eligible for the international relocation payment if your course
-          leads to PGCE + QTS or PGDE + QTS.
-        </p>
 
         <% Applicants::SalariedCourseDetail::ELIGIBLE_COURSE_OPTIONS.each_with_index do |value, i| %>
           <%= f.govuk_radio_button :eligible_course, value, label: { text: value.humanize }, link_errors: i.zero? %>


### PR DESCRIPTION
## Trello Card Link

https://trello.com/c/glMpGVP0/55-trainee-route-place-on-salaried-course

## Description

It uses a `hint` attribute on the question to assess the current employment status
for trainees instead of using HTML markup.

### Screenshots

**From**

<img width="768" alt="image" src="https://github.com/DFE-Digital/international-teacher-relocation-payment/assets/134513241/52f88a00-770b-49ab-b07e-fc85f6335129">


**To**

<img width="751" alt="image" src="https://github.com/DFE-Digital/international-teacher-relocation-payment/assets/134513241/3d00cca2-eb4b-466d-be13-33ad66da5498">


