### PR TITLE
Show validation error on the date_of_birth attribute

### DIFF
--- a/app/models/applicants/personal_detail.rb
+++ b/app/models/applicants/personal_detail.rb
@@ -21,10 +21,19 @@ module Applicants
 
     validate do |record|
       EmailFormatValidator.new(record).validate
+      DayMonthYearDateValidator.new.validate(record, :date_of_birth)
     end
 
     def date_of_birth
-      date_from_hash
+      Date.new(year.to_i, month.to_i, day.to_i)
+    rescue StandardError
+      InvalidDate.new(day:, month:, year:)
+    end
+  end
+
+  InvalidDate = Struct.new(:day, :month, :year, keyword_init: true) do
+    def blank?
+      members.all? { |date_field| public_send(date_field).blank? }
     end
   end
 end

--- a/spec/models/applicants/personal_detail_spec.rb
+++ b/spec/models/applicants/personal_detail_spec.rb
@@ -21,6 +21,26 @@ module Applicants
         expect(model).to validate_inclusion_of(:sex)
           .in_array(Applicants::PersonalDetail::SEX_OPTIONS)
       }
+
+      describe "date_of_birth" do
+        context "when date_of_birth is invalid" do
+          let(:params) { { day: "31", month: "02", year: "2000" } }
+
+          it "is invalid" do
+            expect(model).not_to be_valid
+          end
+        end
+
+        context "when date_of_birth is valid" do
+          let(:params) { { day: "01", month: "01", year: "2000" } }
+
+          it "is valid" do
+            model.valid?
+
+            expect(model.errors["date_of_birth"]).to be_blank
+          end
+        end
+      end
     end
   end
 end

--- a/spec/validators/day_month_year_date_validator_spec.rb
+++ b/spec/validators/day_month_year_date_validator_spec.rb
@@ -1,4 +1,4 @@
-# spec/validators/day_month_year_date_validator_spec.rb
+# spec/validators/an_attribute_validator_spec.rb
 
 require "rails_helper"
 
@@ -8,7 +8,7 @@ RSpec.describe DayMonthYearDateValidator do
     attr_accessor :day, :month, :year
 
     validate do |record|
-      DayMonthYearDateValidator.new.validate(record)
+      DayMonthYearDateValidator.new.validate(record, :an_attribute)
     end
   end
 
@@ -31,7 +31,7 @@ RSpec.describe DayMonthYearDateValidator do
         validatable.month = "2" # Invalid month
         validatable.valid?
 
-        expect(validatable.errors[:day_month_year_date]).to include("Enter a valid date")
+        expect(validatable.errors[:an_attribute]).to include("Enter a valid date")
       end
 
       it "fails validation with negative numbers" do
@@ -39,7 +39,7 @@ RSpec.describe DayMonthYearDateValidator do
         validatable.month = "2" # Invalid month
         validatable.valid?
 
-        expect(validatable.errors[:day_month_year_date]).to include("Enter a valid date")
+        expect(validatable.errors[:an_attribute]).to include("Enter a valid date")
       end
     end
 


### PR DESCRIPTION
Depends on #33 to fix issues with `nil` years or dates that are partially empty

## Trello Card Link

https://trello.com/c/gIQaRF2K/62-application-form-date-of-birth

## Description

Adds day, month, year validation for the `birth day` of the applicant.  The validation will 
make sure that all the fields are present and that the date is valid.

## Technical notes

1. I have reused the `DayMonthYearDateValidator` introduced in #31
2. I have introduced [duplication on the validation](https://github.com/DFE-Digital/international-teacher-relocation-payment/commit/cbb6246d556015f958ed2be81029324ac6ba129d); I have not 
extracted out the duplicated code as I would like to have a simple PR so this story 
can be properly tested. But I will proceed next with the refactoring.

### Next steps

1. Remove duplication between `start_date_contract` and `entry_date`
2. Unify questions in #33 #31 for dates with a single class that will remove duplication. 

## Screenshots

<img width="587" alt="image" src="https://github.com/DFE-Digital/international-teacher-relocation-payment/assets/134513241/013d8a34-5ae3-4110-9a04-d11a8af18966">

<img width="602" alt="image" src="https://github.com/DFE-Digital/international-teacher-relocation-payment/assets/134513241/4abbbb7c-ff5a-46d3-bd25-5f8d117806c5">



