### PR TITLE
Remove dependency from sassc

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -59,7 +59,6 @@ end
 
 group :development do
   gem "annotate"
-  gem "better_errors"
   gem "binding_of_caller"
   gem "web-console"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -72,10 +72,6 @@ GEM
       activerecord (>= 3.2, < 8.0)
       rake (>= 10.4, < 14.0)
     ast (2.4.2)
-    better_errors (2.10.0)
-      erubi (>= 1.0.0)
-      rack (>= 0.9.0)
-      rouge (>= 1.0.0)
     bindex (0.8.1)
     binding_of_caller (1.0.0)
       debug_inspector (>= 0.0.1)
@@ -264,7 +260,6 @@ GEM
     reline (0.3.4)
       io-console (~> 0.5)
     rexml (3.2.5)
-    rouge (4.1.2)
     rspec-core (3.12.2)
       rspec-support (~> 3.12.0)
     rspec-expectations (3.12.3)
@@ -363,7 +358,6 @@ PLATFORMS
 
 DEPENDENCIES
   annotate
-  better_errors
   binding_of_caller
   bootsnap
   brakeman
@@ -401,4 +395,4 @@ RUBY VERSION
    ruby 3.1.3p185
 
 BUNDLED WITH
-   2.1.2
+   2.1.4


### PR DESCRIPTION
### Description

Sassc dependency was inadvertently introduced in #30 as a side effect of adding the 
gem `better_errors`. This library is deprecated although it is under maintenance. They 
recommend users to move to Dart Sass.

On this PR I am removing this dependency so we can run the application with the following error:

```
iCalling `DidYouMean::SPELL_CHECKERS.merge!(error_name => spell_checker)' has been deprecated. Please call `DidYouMean.correct_error(error_name, spell_checker)' instead.
Calling `DidYouMean::SPELL_CHECKERS.merge!(error_name => spell_checker)' has been deprecated. Please call `DidYouMean.correct_error(error_name, spell_checker)' instead.
/Users/pmanrubia/.asdf/installs/ruby/3.1.3/lib/ruby/gems/3.1.0/gems/bootsnap-1.16.0/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:17:in `require': cannot load such file -- sassc (LoadError)
	from /Users/pmanrubia/.asdf/installs/ruby/3.1.3/lib/ruby/gems/3.1.0/gems/bootsnap-1.16.0/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:17:in `require'
	from /Users/pmanrubia/.asdf/installs/ruby/3.1.3/lib/ruby/gems/3.1.0/gems/better_errors-2.10.0/lib/better_errors/error_page_style.rb:1:in `<main>'
	from /Users/pmanrubia/.asdf/installs/ruby/3.1.3/lib/ruby/gems/3.1.0/gems/bootsnap-1.16.0/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:32:in `require'
	from /Users/pmanrubia/.asdf/installs/ruby/3.1.3/lib/ruby/gems/3.1.0/gems/bootsnap-1.16.0/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:32:in `require'
	from /Users/pmanrubia/.asdf/installs/ruby/3.1.3/lib/ruby/gems/3.1.0/gems/better_errors-2.10.0/lib/better_errors/error_page.rb:5:in `<main>'
	from /Users/pmanrubia/.asdf/installs/ruby/3.1.3/lib/ruby/gems/3.1.0/gems/bootsnap-1.16.0/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:32:in `require'
	from /Users/pmanrubia/.asdf/installs/ruby/3.1.3/lib/ruby/gems/3.1.0/gems/bootsnap-1.16.0/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:32:in `require'
	from /Users/pmanrubia/.asdf/installs/ruby/3.1.3/lib/ruby/gems/3.1.0/gems/better_errors-2.10.0/lib/better_errors.rb:8:in `<main>'
	from /Users/pmanrubia/.asdf/installs/ruby/3.1.3/lib/ruby/gems/3.1.0/gems/bootsnap-1.16.0/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:32:in `require'
	from /Users/pmanrubia/.asdf/installs/ruby/3.1.3/lib/ruby/gems/3.1.0/gems/bootsnap-1.16.0/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:32:in `require'
	from /Users/pmanrubia/.asdf/installs/bundler/2.1.4/lib/bundler/runtime.rb:74:in `block (2 levels) in require'
	from /Users/pmanrubia/.asdf/installs/bundler/2.1.4/lib/bundler/runtime.rb:69:in `each'
	from /Users/pmanrubia/.asdf/installs/bundler/2.1.4/lib/bundler/runtime.rb:69:in `block in require'
	from /Users/pmanrubia/.asdf/installs/bundler/2.1.4/lib/bundler/runtime.rb:58:in `each'
	from /Users/pmanrubia/.asdf/installs/bundler/2.1.4/lib/bundler/runtime.rb:58:in `require'
	from /Users/pmanrubia/.asdf/installs/bundler/2.1.4/lib/bundler.rb:174:in `require'
	from /Users/pmanrubia/work/dfe/international-teacher-relocation-payment/config/application.rb:21:in `<main>'
	from /Users/pmanrubia/.asdf/installs/ruby/3.1.3/lib/ruby/gems/3.1.0/gems/bootsnap-1.16.0/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:32:in `require'
	from /Users/pmanrubia/.asdf/installs/ruby/3.1.3/lib/ruby/gems/3.1.0/gems/bootsnap-1.16.0/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:32:in `require'
	from /Users/pmanrubia/.asdf/installs/ruby/3.1.3/lib/ruby/gems/3.1.0/gems/railties-7.0.5/lib/rails/command/actions.rb:22:in `require_application!'
	from /Users/pmanrubia/.asdf/installs/ruby/3.1.3/lib/ruby/gems/3.1.0/gems/railties-7.0.5/lib/rails/command/actions.rb:14:in `require_application_and_environment!'
	from /Users/pmanrubia/.asdf/installs/ruby/3.1.3/lib/ruby/gems/3.1.0/gems/railties-7.0.5/lib/rails/commands/console/console_command.rb:105:in `perform'
	from /Users/pmanrubia/.asdf/installs/ruby/3.1.3/lib/ruby/gems/3.1.0/gems/thor-1.2.2/lib/thor/command.rb:27:in `run'
	from /Users/pmanrubia/.asdf/installs/ruby/3.1.3/lib/ruby/gems/3.1.0/gems/thor-1.2.2/lib/thor/invocation.rb:127:in `invoke_command'
	from /Users/pmanrubia/.asdf/installs/ruby/3.1.3/lib/ruby/gems/3.1.0/gems/thor-1.2.2/lib/thor.rb:392:in `dispatch'
	from /Users/pmanrubia/.asdf/installs/ruby/3.1.3/lib/ruby/gems/3.1.0/gems/railties-7.0.5/lib/rails/command/base.rb:87:in `perform'
	from /Users/pmanrubia/.asdf/installs/ruby/3.1.3/lib/ruby/gems/3.1.0/gems/railties-7.0.5/lib/rails/command.rb:48:in `invoke'
	from /Users/pmanrubia/.asdf/installs/ruby/3.1.3/lib/ruby/gems/3.1.0/gems/railties-7.0.5/lib/rails/commands.rb:18:in `<main>'
	from /Users/pmanrubia/.asdf/installs/ruby/3.1.3/lib/ruby/gems/3.1.0/gems/bootsnap-1.16.0/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:32:in `require'
	from /Users/pmanrubia/.asdf/installs/ruby/3.1.3/lib/ruby/gems/3.1.0/gems/bootsnap-1.16.0/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:32:in `require'
	from bin/rails:4:in `<main>
```

