### PR TITLE
Add extra validations to date of birth

### DIFF
--- a/app/models/applicants/personal_detail.rb
+++ b/app/models/applicants/personal_detail.rb
@@ -16,6 +16,7 @@ module Applicants
     validates :email_address, presence: true
     validates :phone_number, presence: true
     validates :date_of_birth, presence: true
+    validate :date_of_birth_not_in_future
     validates :sex, presence: true, inclusion: { in: SEX_OPTIONS }
     validates :passport_number, presence: true
     validates :nationality, presence: true, inclusion: { in: NATIONALITIES }
@@ -33,11 +34,23 @@ module Applicants
     rescue StandardError
       InvalidDate.new(day:, month:, year:)
     end
+
+  private
+
+    def date_of_birth_not_in_future
+      return unless date_of_birth.present? && date_of_birth > Date.zone.today
+
+      errors.add(:date_of_birth, "cannot be in the future")
+    end
   end
 
   InvalidDate = Struct.new(:day, :month, :year, keyword_init: true) do
     def blank?
       members.all? { |date_field| public_send(date_field).blank? }
+    end
+
+    def present?
+      false
     end
   end
 end

--- a/app/models/applicants/personal_detail.rb
+++ b/app/models/applicants/personal_detail.rb
@@ -17,6 +17,7 @@ module Applicants
     validates :phone_number, presence: true
     validates :date_of_birth, presence: true
     validate :date_of_birth_not_in_future
+    validate :age_less_than_maximum
     validates :sex, presence: true, inclusion: { in: SEX_OPTIONS }
     validates :passport_number, presence: true
     validates :nationality, presence: true, inclusion: { in: NATIONALITIES }
@@ -38,11 +39,20 @@ module Applicants
   private
 
     def date_of_birth_not_in_future
-      return unless date_of_birth.present? && date_of_birth > Date.zone.today
+      return unless date_of_birth.present? && date_of_birth > Date.current
 
       errors.add(:date_of_birth, "cannot be in the future")
     end
+
+    def age_less_than_maximum
+      return unless date_of_birth.present? && (Date.current.year - date_of_birth.year) >= MAX_AGE
+
+      errors.add(:date_of_birth, "age should be below #{MAX_AGE} years")
+    end
   end
+
+  MAX_AGE = 80
+  private_constant :MAX_AGE
 
   InvalidDate = Struct.new(:day, :month, :year, keyword_init: true) do
     def blank?

--- a/spec/models/applicants/personal_detail_spec.rb
+++ b/spec/models/applicants/personal_detail_spec.rb
@@ -36,6 +36,14 @@ module Applicants
           end
         end
 
+        context "when date_of_birth is the future" do
+          let(:params) { { day: "01", month: "01", year: "3000" } }
+
+          it "is invalid" do
+            expect(model).not_to be_valid
+          end
+        end
+
         context "when date_of_birth is valid" do
           let(:params) { { day: "01", month: "01", year: "2000" } }
 

--- a/spec/models/applicants/personal_detail_spec.rb
+++ b/spec/models/applicants/personal_detail_spec.rb
@@ -44,6 +44,14 @@ module Applicants
           end
         end
 
+        context "when age is over 80 years old" do
+          let(:params) { { day: "01", month: "01", year: 81.years.ago.year } }
+
+          it "is invalid" do
+            expect(model).not_to be_valid
+          end
+        end
+
         context "when date_of_birth is valid" do
           let(:params) { { day: "01", month: "01", year: "2000" } }
 

--- a/spec/models/applicants/personal_detail_spec.rb
+++ b/spec/models/applicants/personal_detail_spec.rb
@@ -37,7 +37,7 @@ module Applicants
         end
 
         context "when date_of_birth is the future" do
-          let(:params) { { day: "01", month: "01", year: "3000" } }
+          let(:params) { { day: Date.tomorrow.day, month: Date.tomorrow.month, year: Date.tomorrow.year } }
 
           it "is invalid" do
             expect(model).not_to be_valid


### PR DESCRIPTION
## Trello Card Link

https://trello.com/c/gIQaRF2K/62-application-form-date-of-birth

## Description

Add two new validations to the date of birth of an applicant:

1. The date of birth **must** not be in the future
2. Applicants **must** be below 80 years old.

## Screenshots

<img width="607" alt="image" src="https://github.com/DFE-Digital/international-teacher-relocation-payment/assets/134513241/4e55f5f5-c8cd-473a-bfa5-4c84c3ae3b3c">

<img width="641" alt="image" src="https://github.com/DFE-Digital/international-teacher-relocation-payment/assets/134513241/a303daa8-4c8b-477a-b1d0-e1b4663170c5">

