### PR TITLE
Include postcode validations

### DIFF
--- a/app/models/applicants/personal_detail.rb
+++ b/app/models/applicants/personal_detail.rb
@@ -23,7 +23,7 @@ module Applicants
     validates :nationality, presence: true, inclusion: { in: NATIONALITIES }
     validates :address_line_1, presence: true
     validates :city, presence: true
-    validates :postcode, presence: true
+    validates :postcode, presence: true, postcode: true
 
     validate do |record|
       EmailFormatValidator.new(record).validate

--- a/spec/models/applicants/employment_detail_spec.rb
+++ b/spec/models/applicants/employment_detail_spec.rb
@@ -6,6 +6,8 @@ module Applicants
   describe EmploymentDetail do
     let(:params) { {} }
 
+    include_examples "a valid UK postcode", described_class, :school_postcode
+
     subject { described_class.new(params) }
 
     describe "validations" do

--- a/spec/models/applicants/personal_detail_spec.rb
+++ b/spec/models/applicants/personal_detail_spec.rb
@@ -27,21 +27,7 @@ module Applicants
                            .in_array(Applicants::PersonalDetail::SEX_OPTIONS)
       }
 
-      describe "postcode validation" do
-        it "accepts valid postcodes" do
-          model.postcode = "SW1A 1AA"
-          model.valid?
-
-          expect(model.errors[:postcode]).to be_empty
-        end
-
-        it "rejects invalid postcodes" do
-          model.postcode = "Invalid postcode"
-          model.valid?
-
-          expect(model.errors[:postcode]).to include("Enter a valid postcode (for example, BN1 1AA)")
-        end
-      end
+      include_examples "a valid UK postcode", described_class
 
       describe "date_of_birth" do
         context "when date_of_birth is invalid" do

--- a/spec/models/applicants/personal_detail_spec.rb
+++ b/spec/models/applicants/personal_detail_spec.rb
@@ -27,6 +27,22 @@ module Applicants
                            .in_array(Applicants::PersonalDetail::SEX_OPTIONS)
       }
 
+      describe "postcode validation" do
+        it "accepts valid postcodes" do
+          model.postcode = "SW1A 1AA"
+          model.valid?
+
+          expect(model.errors[:postcode]).to be_empty
+        end
+
+        it "rejects invalid postcodes" do
+          model.postcode = "Invalid postcode"
+          model.valid?
+
+          expect(model.errors[:postcode]).to include("Enter a valid postcode (for example, BN1 1AA)")
+        end
+      end
+
       describe "date_of_birth" do
         context "when date_of_birth is invalid" do
           let(:params) { { day: "31", month: "02", year: "2000" } }

--- a/spec/support/postcode_validation.rb
+++ b/spec/support/postcode_validation.rb
@@ -1,0 +1,15 @@
+RSpec.shared_examples "a valid UK postcode" do |klass|
+  it "accepts valid postcodes" do
+    model = klass.new(postcode: "SW1A 1AA")
+    model.valid?
+
+    expect(model.errors[:postcode]).to be_empty
+  end
+
+  it "rejects invalid postcodes" do
+    model = klass.new(postcode: "Invalid postcode")
+    model.valid?
+
+    expect(model.errors[:postcode]).to include("Enter a valid postcode (for example, BN1 1AA)")
+  end
+end

--- a/spec/support/postcode_validation.rb
+++ b/spec/support/postcode_validation.rb
@@ -1,15 +1,15 @@
-RSpec.shared_examples "a valid UK postcode" do |klass|
+RSpec.shared_examples "a valid UK postcode" do |klass, attribute_name = :postcode|
   it "accepts valid postcodes" do
-    model = klass.new(postcode: "SW1A 1AA")
+    model = klass.new(attribute_name => "SW1A 1AA")
     model.valid?
 
-    expect(model.errors[:postcode]).to be_empty
+    expect(model.errors[attribute_name]).to be_empty
   end
 
   it "rejects invalid postcodes" do
-    model = klass.new(postcode: "Invalid postcode")
+    model = klass.new(attribute_name => "Invalid postcode")
     model.valid?
 
-    expect(model.errors[:postcode]).to include("Enter a valid postcode (for example, BN1 1AA)")
+    expect(model.errors[attribute_name]).to include("Enter a valid postcode (for example, BN1 1AA)")
   end
 end


### PR DESCRIPTION
## Description

The postcode validator was introduced in #3 and it was only applied to 
the school address. On #41 we introduced the address for the applicant, 
hence we need to apply the same validation.

Postcode validation is used for applicants and schools, so it makes sense to
check that it is enabled on both models.

I am extracting a Shared Examples file for the postcode so it can be reused also
on the school:

```ruby
include_examples "a valid UK postcode", described_class
```

For `Applicants::PersonalDetail`
```bash
  validations
    ...
    is expected to validate that :city cannot be empty/falsy
    is expected not to validate that :county cannot be empty/falsy
    is expected to validate that :postcode cannot be empty/falsy
    is expected to validate that :sex is either ‹"female"›, ‹"male"›, or ‹"other"›
    ***accepts valid postcodes***
    ***rejects invalid postcodes***
    date_of_birth
      when date_of_birth is invalid
        is invalid
      when date_of_birth is the future
        is invalid
    ...
Finished in 0.31215 seconds (files took 3.96 seconds to load)
19 examples, 0 failures
```

For: `Applicants::EmploymentDetail`

```bash
***accepts valid postcodes***
***rejects invalid postcodes***
validations
  is expected to validate that :school_name cannot be empty/falsy
  is expected to validate that :school_headteacher_name cannot be empty/falsy

Finished in 0.31008 seconds (files took 4.21 seconds to load)
4 examples, 0 failures
```

