### PR TITLE
Validate phone number with international codes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,6 +23,8 @@ gem "govuk-components", "4.0.0"
 gem "govuk_design_system_formbuilder"
 # UK postcode parsing and validation for Ruby
 gem "uk_postcode"
+# Phone number validations: https://design-system.service.gov.uk/patterns/telephone-numbers/
+gem "phonelib"
 ###############
 
 gem "config", "~> 4.1"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -212,6 +212,7 @@ GEM
     parser (3.2.2.1)
       ast (~> 2.4.1)
     pg (1.5.3)
+    phonelib (0.8.2)
     pry (0.14.2)
       coderay (~> 1.1)
       method_source (~> 1.0)
@@ -375,6 +376,7 @@ DEPENDENCIES
   jbuilder
   launchy
   pg (~> 1.1)
+  phonelib
   pry-byebug
   puma (~> 6.3)
   rails (~> 7.0.4)

--- a/app/models/applicants/personal_detail.rb
+++ b/app/models/applicants/personal_detail.rb
@@ -14,6 +14,7 @@ module Applicants
     validates :family_name, presence: true
     validates :email_address, presence: true
     validates :phone_number, presence: true
+    validates :phone_number, phone: { possible: true, allow_blank: true, types: %i[voip mobile] }
     validates :date_of_birth, presence: true
     validate :date_of_birth_not_in_future
     validate :age_less_than_maximum

--- a/app/models/applicants/personal_detail.rb
+++ b/app/models/applicants/personal_detail.rb
@@ -14,7 +14,7 @@ module Applicants
     validates :family_name, presence: true
     validates :email_address, presence: true
     validates :phone_number, presence: true
-    validates :phone_number, phone: { possible: true, allow_blank: true, types: %i[voip mobile] }
+    validates :phone_number, phone: { possible: true, types: %i[voip mobile] }
     validates :date_of_birth, presence: true
     validate :date_of_birth_not_in_future
     validate :age_less_than_maximum

--- a/app/views/applicants/personal_details/new.html.erb
+++ b/app/views/applicants/personal_details/new.html.erb
@@ -11,7 +11,10 @@
       <%= f.govuk_text_field :given_name, label: { text: "Enter your given name, as it appears on your passport", size: "s" } %>
       <%= f.govuk_text_field :family_name, label: { text: "Enter your family name, as it appears on your passport", size: "s" } %>
       <%= f.govuk_text_field :email_address, label: { text: "Enter your current email address", size: "s" }, hint: { text: "We will use this to contact you so please make sure you have entered it correctly." } %>
-      <%= f.govuk_text_field :phone_number, label: { text: "Enter your current phone number", size: "s" }, hint: { text: "We will use this to contact you so please make sure you have entered it correctly." } %>
+      <%= f.govuk_text_field :phone_number,
+        label: { text: "Enter your current phone number", size: "s" },
+        hint: { text: "For international numbers include the country code. We will use this to contact you so please make sure you have entered it correctly." }
+      %>
       <%= f.govuk_date_field :date_of_birth, date_of_birth: true, legend: { text: "Enter your date of birth, as it appears on your passport", size: "s" } %>
 
       <%= f.govuk_fieldset legend: { text: 'Enter your address', size: 's' } do %>

--- a/config/initializers/phone_number.rb
+++ b/config/initializers/phone_number.rb
@@ -1,0 +1,1 @@
+Phonelib.default_country = "GB"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -90,6 +90,7 @@ en:
               invalid: Enter an email address in the correct format, like name@example.com
             phone_number:
               blank: Enter your phone number
+              invalid: Enter a telephone number, like 07700 900 982 or +34 626 587 210’
             date_of_birth:
               blank: Enter your date of birth
             sex:

--- a/spec/models/applicants/personal_detail_spec.rb
+++ b/spec/models/applicants/personal_detail_spec.rb
@@ -29,12 +29,53 @@ module Applicants
 
       include_examples "a valid UK postcode", described_class
 
+      describe "phone_number" do
+        [
+          "07700900000", # UK number
+          "07700 900 000", # UK number with spaces
+          "07700 900-000", # UK number with hyphens
+          "7700 900-000", # UK number without `0`
+          "+447702909898", # UK number with country code
+          "+44 0 7702 909 898", # UK number with country code, spaces and `0`
+          "+44 (0)7702-909-898", # UK number with country code, spaces, and `(0)`
+          "44 (0) 7702 909 898", # UK number with country code, spaces, `(0)` and no `+`
+          "+34 985 256 634", # Spanish number (home) with spaces
+          "+34 626577222", # Spanish number (mobile) without spaces
+          "+34626577222", # Spanish number (mobile) without spaces and with country code
+          "34 626-577-222", # Spanish number (mobile) with spaces and hyphens
+        ].each do |valid_number|
+          it "is valid for #{valid_number}" do
+            model.phone_number = valid_number
+            model.valid?
+
+            expect(model.errors["phone_number"]).to be_blank
+          end
+        end
+
+        [
+          "700900000", # UK number without `0` missing digit
+          "700 900 000", # UK number without `0` with spaces missing digit
+          "+347702909898", # Spanish number with country code extra digits
+          "+34 0 7702 909 898", # Spanish number with country code and `0` as extra digit
+          "+34 985 256", # spanish number (home) with spaces and missing digits
+        ].each do |invalid_number|
+          it "is invalid for #{invalid_number}" do
+            model.phone_number = invalid_number
+            model.valid?
+
+            expect(model.errors["phone_number"]).not_to be_blank
+          end
+        end
+      end
+
       describe "date_of_birth" do
         context "when date_of_birth is invalid" do
           let(:params) { { day: "31", month: "02", year: "2000" } }
 
           it "is invalid" do
-            expect(model).not_to be_valid
+            model.valid?
+
+            expect(model.errors["date_of_birth"]).not_to be_blank
           end
         end
 

--- a/spec/models/applicants/personal_detail_spec.rb
+++ b/spec/models/applicants/personal_detail_spec.rb
@@ -28,45 +28,7 @@ module Applicants
       }
 
       include_examples "a valid UK postcode", described_class
-
-      describe "phone_number" do
-        [
-          "07700900000", # UK number
-          "07700 900 000", # UK number with spaces
-          "07700 900-000", # UK number with hyphens
-          "7700 900-000", # UK number without `0`
-          "+447702909898", # UK number with country code
-          "+44 0 7702 909 898", # UK number with country code, spaces and `0`
-          "+44 (0)7702-909-898", # UK number with country code, spaces, and `(0)`
-          "44 (0) 7702 909 898", # UK number with country code, spaces, `(0)` and no `+`
-          "+34 985 256 634", # Spanish number (home) with spaces
-          "+34 626577222", # Spanish number (mobile) without spaces
-          "+34626577222", # Spanish number (mobile) without spaces and with country code
-          "34 626-577-222", # Spanish number (mobile) with spaces and hyphens
-        ].each do |valid_number|
-          it "is valid for #{valid_number}" do
-            model.phone_number = valid_number
-            model.valid?
-
-            expect(model.errors["phone_number"]).to be_blank
-          end
-        end
-
-        [
-          "700900000", # UK number without `0` missing digit
-          "700 900 000", # UK number without `0` with spaces missing digit
-          "+347702909898", # Spanish number with country code extra digits
-          "+34 0 7702 909 898", # Spanish number with country code and `0` as extra digit
-          "+34 985 256", # spanish number (home) with spaces and missing digits
-        ].each do |invalid_number|
-          it "is invalid for #{invalid_number}" do
-            model.phone_number = invalid_number
-            model.valid?
-
-            expect(model.errors["phone_number"]).not_to be_blank
-          end
-        end
-      end
+      include_examples "validates phone number with international prefix", described_class, :phone_number
 
       describe "date_of_birth" do
         context "when date_of_birth is invalid" do

--- a/spec/support/phone_number_validations.rb
+++ b/spec/support/phone_number_validations.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+RSpec.shared_examples "validates phone number with international prefix" do |klass, attribute|
+  subject { klass.new }
+
+  describe "Phone number validations for attribute: #{attribute}" do
+    [
+      "07700900000", # UK number
+      "07700 900 000", # UK number with spaces
+      "07700 900-000", # UK number with hyphens
+      "7700 900-000", # UK number without `0`
+      "+447702909898", # UK number with country code
+      "+44 0 7702 909 898", # UK number with country code, spaces and `0`
+      "+44 (0)7702-909-898", # UK number with country code, spaces, and `(0)`
+      "44 (0) 7702 909 898", # UK number with country code, spaces, `(0)` and no `+`
+      "+34 985 256 634", # Spanish number (home) with spaces
+      "+34 626577222", # Spanish number (mobile) without spaces
+      "+34626577222", # Spanish number (mobile) without spaces and with country code
+      "34 626-577-222", # Spanish number (mobile) with spaces and hyphens
+    ].each do |valid_number|
+      it "is valid for #{valid_number}" do
+        subject.phone_number = valid_number
+        subject.valid?
+
+        expect(subject.errors[attribute]).to be_blank
+      end
+    end
+
+    [
+      "700900000", # UK number without `0` missing digit
+      "700 900 000", # UK number without `0` with spaces missing digit
+      "+347702909898", # Spanish number with country code extra digits
+      "+34 0 7702 909 898", # Spanish number with country code and `0` as extra digit
+      "+34 985 256", # spanish number (home) with spaces and missing digits
+    ].each do |invalid_number|
+      it "is invalid for #{invalid_number}" do
+        subject.phone_number = invalid_number
+        subject.valid?
+
+        expect(subject.errors[attribute]).not_to be_blank
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Trello Card Link

https://trello.com/c/PV6vpXTU/61-application-form-phone-number

## Description
The [design system for GOV.UK for phone numbers](https://design-system.service.gov.uk/patterns/telephone-numbers/) is still not conclusive when it 
comes to mobile numbers, but it has some experimental guidelines that I have
followed on this PR.

For the validations, at the time of writing this commit, the design system suggests 
[using a Library from Google named libphonenumber](https://github.com/google/libphonenumber). There is no implementation for
Ruby, but they point you towards one of the following:

1. [GitHub - ianks/mini_phone](https://github.com/ianks/mini_phone): A fast phone number parser, validator and formatter 
for Ruby. This gem binds to Google’s C++ libphonenumber for spec-compliance 
and performance.
3. [GitHub - daddyz/phonelib](https://github.com/daddyz/phonelib): Ruby gem for phone validation and formatting 
4. using google libphonenumber library data
5. [GitHub - mobi/telephone_number](https://github.com/mobi/telephone_number): Phone number validation for Ruby

We have chosen  [GitHub - daddyz/phonelib](https://github.com/daddyz/phonelib) as this one seems more stable and maintained. 

### Notes

1. As per the guidelines: `Let users enter telephone numbers in whatever format 
is familiar to them. Allow for additional spaces, hyphens, dashes and brackets, and 
be able to accommodate country and area codes.`
3. We use the validation via a Ruby extension of Google Library
4. We set the default telephone numbers to `GB` via an initializer. Not a fan of how it looks, but I can't think of a better way other than adding it to `application.rb`