### PR TITLE
Update subjects: remove general science

### DIFF
--- a/app/models/applicants/subject.rb
+++ b/app/models/applicants/subject.rb
@@ -5,7 +5,7 @@ module Applicants
     include ActiveModel::Model
     attr_accessor :subject
 
-    SUBJECT_OPTIONS = %w[physics languages general_science other].freeze
+    SUBJECT_OPTIONS = %w[physics languages other].freeze
 
     validates :subject, presence: true, inclusion: { in: SUBJECT_OPTIONS }
 


### PR DESCRIPTION
## Description

As instructed, we are removing the option `general science` from the subject questions.

## Trello Card Link

https://trello.com/c/KBsBnpwk/56-trainee-route-training-subject
