### PR TITLE
Add Urn for application numbers

### DIFF
--- a/app/models/urn.rb
+++ b/app/models/urn.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+# Urn represents a Uniform Resource Name (URN) generator.
+# It generates a URN with a fixed prefix and a random alphanumeric suffix.
+#
+# Uses DEC alphabet + 2..9 numbers to decrease ambiguity.
+#
+# Example:
+#
+#   Urn.new.value # => "IRP1A2B3C"
+#
+# As it implements `.dump` and `.load`, it can be used with `serialize` as
+# an Active Model. It can be included as an attribute in your model
+# and automatically handle serialization/deserialization.
+#
+# Example with ActiveRecord:
+#   app/models/your_model.rb
+#
+#   class YourModel < ActiveRecord::Base
+#     serialize :urn, Urn
+#   end
+#
+#   your_model = YourModel.new
+#   your_model.urn = Urn.new
+#   your_model.save
+#   your_model.reload
+#   puts your_model.urn.value
+#
+#   Urn.dump(Urn.new) # => "IRPGA2B3C"
+#   Urn.load("IRPGA2B3C") # => "IRPGA2B3C"
+#
+#  Duplications
+#    Total number of combinations is: 26^6 = 308,915,776 ~ 310M
+class Urn
+  attr_reader :value
+
+  def initialize
+    @value = Urn.generate_urn
+  end
+
+  def self.dump(value)
+    value
+  end
+
+  def self.load(value)
+    value || generate_urn
+  end
+
+  CHARSET = %w[A B C D E F H J K L M N P R S T U V 2 3 4 5 6 7 8 9].freeze
+  PREFIX = "IRP"
+  LENGTH = 6
+  private_constant :CHARSET, :PREFIX, :LENGTH
+
+  def self.generate_urn
+    PREFIX + Array.new(LENGTH) { CHARSET.sample }.join
+  end
+
+  private_methods :generate_urn
+end

--- a/spec/models/urn_spec.rb
+++ b/spec/models/urn_spec.rb
@@ -1,0 +1,44 @@
+# spec/models/urn_spec.rb
+require "rails_helper"
+
+RSpec.describe Urn do
+  subject(:urn) { described_class.new }
+
+  it "has a value" do
+    expect(urn.value).to be_present
+  end
+
+  it "generates a Urn with a prefix of 'IRP'" do
+    expect(urn.value).to start_with("IRP")
+  end
+
+  it "generates a Urn with a length of 8" do
+    expect(urn.value.length).to eq(9)
+  end
+
+  it "generates a Urn with a suffix of 6 characters" do
+    expect(urn.value[3..].length).to eq(6)
+  end
+
+  it "generates a Urn with a suffix of only characters in the CHARSET" do
+    charset = %w[A B C D E F H J K L M N P R S T U V 0 1 2 3 4 5 6 7 8 9]
+
+    expect(urn.value[3..].chars).to all(be_in(charset))
+  end
+
+  describe ".dump" do
+    it "returns the given value" do
+      expect(described_class.dump("IRPG2345")).to eq("IRPG2345")
+    end
+  end
+
+  describe ".load" do
+    it "generates a new Urn when `value` is `nil`" do
+      expect(described_class.load(nil)).not_to be_nil
+    end
+
+    it "returns the given value when `value` is not `nil`" do
+      expect(described_class.load("IRPG2345")).to eq("IRPG2345")
+    end
+  end
+end


### PR DESCRIPTION
## Trello Card Link

https://trello.com/c/acwINfog/32-m-generate-urn-for-applications-on-submission

## Description

`Urn` represents a Uniform Resource Name (URN) generator. It generates a URN 
with a fixed prefix and a random alphanumeric suffix.

Uses [DEC alphabet](https://gunkies.org/wiki/DEC_alphabet) + 2..9 numbers to decrease ambiguity.

```ruby
Urn.new.value # => "IRPCA2B39"
```

 As it implements `.dump` and `.load`, it can be used with `serialize` as
 an Active Model. It can be included as an attribute in your model
 and automatically handle serialization/deserialization.

Example with ActiveRecord:

```ruby
#app/models/your_model.rb

 class YourModel < ActiveRecord::Base
   serialize :urn, Urn
 end

 your_model = YourModel.new
 your_model.urn = Urn.new
 your_model.save
 your_model.reload
 puts your_model.urn.value

 Urn.dump(Urn.new) # => "IRPCA2B39"
 Urn.load("IRPCA2B39") # => "IRPCA2B39"
```

### Notes

1. Implementation details are [inspired in a comment](https://github.com/alphagov/govuk-design-system-backlog/issues/85#issuecomment-630716567) from @edwardhorsford regarding best practices in reference numbers
2. I have not added a checksum yet, as I need more clarification around validations.
3. I am not using consecutive numbers
4. I avoid alpha characters that can be confused with numbers

### Duplications

With the selected charset and a length of `6` we have 310M possible combinations. Considering the 
number of applicants that we will have on this applications, we think that this is good enough for now. 

```ruby
CHARSET = %w[A B C D E F H J K L M N P R S T U V 0 1 2 3 4 5 6 7 8 9].freeze`
LENGTH = 6
```

