### PR TITLE
Restore foreign key in migration for schools

### DIFF
--- a/db/migrate/20230612153024_create_schools.rb
+++ b/db/migrate/20230612153024_create_schools.rb
@@ -1,6 +1,7 @@
 class CreateSchools < ActiveRecord::Migration[7.0]
   def change
     create_table :schools do |t|
+      t.references :applicant, null: false, foreign_key: true
       t.string :postcode
       t.string :name
       t.string :headteacher_name


### PR DESCRIPTION
### Description

It seems that this was lost in a merge/rebase and we can't run a 
clean db:migrate from a blank database. This is not critical, because 
we usually load the database with rails db:setup, but it is worth 
having it back.

