### PR TITLE
Remove old address columns from `Applicant`

### DIFF
--- a/app/models/applicant.rb
+++ b/app/models/applicant.rb
@@ -5,11 +5,7 @@
 # Table name: applicants
 #
 #  id                :bigint           not null, primary key
-#  address_line_1    :string
-#  address_line_2    :string
 #  application_route :string
-#  city              :string
-#  county            :string
 #  date_of_birth     :date
 #  date_of_entry     :date
 #  email_address     :text
@@ -18,7 +14,6 @@
 #  nationality       :text
 #  passport_number   :text
 #  phone_number      :text
-#  postcode          :string
 #  sex               :text
 #  subject           :text
 #  visa_type         :text

--- a/db/migrate/20230615132013_remove_address_columns_from_applicant.rb
+++ b/db/migrate/20230615132013_remove_address_columns_from_applicant.rb
@@ -1,0 +1,9 @@
+class RemoveAddressColumnsFromApplicant < ActiveRecord::Migration[7.0]
+  def change
+    remove_column :applicants, :address_line_1, :string
+    remove_column :applicants, :address_line_2, :string
+    remove_column :applicants, :city, :string
+    remove_column :applicants, :county, :string
+    remove_column :applicants, :postcode, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_06_13_110623) do
+ActiveRecord::Schema[7.0].define(version: 2023_06_15_132013) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -54,11 +54,6 @@ ActiveRecord::Schema[7.0].define(version: 2023_06_13_110623) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "application_route"
-    t.string "address_line_1"
-    t.string "address_line_2"
-    t.string "city"
-    t.string "county"
-    t.string "postcode"
     t.bigint "school_id"
     t.index ["school_id"], name: "index_applicants_on_school_id"
   end

--- a/spec/factories/applicants.rb
+++ b/spec/factories/applicants.rb
@@ -3,11 +3,7 @@
 # Table name: applicants
 #
 #  id                :bigint           not null, primary key
-#  address_line_1    :string
-#  address_line_2    :string
 #  application_route :string
-#  city              :string
-#  county            :string
 #  date_of_birth     :date
 #  date_of_entry     :date
 #  email_address     :text
@@ -16,7 +12,6 @@
 #  nationality       :text
 #  passport_number   :text
 #  phone_number      :text
-#  postcode          :string
 #  sex               :text
 #  subject           :text
 #  visa_type         :text


### PR DESCRIPTION
## Description

As a follow-up of #62, we need to remove all the address fields from an
`Applicant` as they are now stored on the polymorphic entity: `Address`

