### PR TITLE
Add exit pages for Trainees and Teachers

### DIFF
--- a/app/controllers/applicants/employment_details_controller.rb
+++ b/app/controllers/applicants/employment_details_controller.rb
@@ -2,6 +2,8 @@
 
 module Applicants
   class EmploymentDetailsController < ApplicationController
+    before_action :set_applicant
+
     def new
       @employment_detail = EmploymentDetail.new
     end
@@ -10,7 +12,6 @@ module Applicants
       @employment_detail = EmploymentDetail.new(employment_detail_params)
 
       if @employment_detail.valid?
-        @applicant = Applicant.find(session[:applicant_id])
         @applicant.create_school!(school_params)
 
         @applicant.create_application!(
@@ -26,6 +27,10 @@ module Applicants
     end
 
   private
+
+    def set_applicant
+      @applicant = Applicant.find(session[:applicant_id])
+    end
 
     def employment_detail_params
       params.require(:applicants_employment_detail).permit(

--- a/app/controllers/applicants/employment_details_controller.rb
+++ b/app/controllers/applicants/employment_details_controller.rb
@@ -2,8 +2,6 @@
 
 module Applicants
   class EmploymentDetailsController < ApplicationController
-    before_action :set_applicant
-
     def new
       @employment_detail = EmploymentDetail.new
     end
@@ -12,10 +10,10 @@ module Applicants
       @employment_detail = EmploymentDetail.new(employment_detail_params)
 
       if @employment_detail.valid?
-        @employment_detail.applicant = @applicant
+        @employment_detail.applicant = current_applicant
         @employment_detail.save!
 
-        Application.register_for_applicant!(@applicant)
+        Application.register_for_applicant!(current_applicant)
 
         redirect_to(applicants_submission_path)
       else
@@ -24,10 +22,6 @@ module Applicants
     end
 
   private
-
-    def set_applicant
-      @applicant = Applicant.find(session[:applicant_id])
-    end
 
     def employment_detail_params
       params.require(:applicants_employment_detail).permit(

--- a/app/controllers/applicants/employment_details_controller.rb
+++ b/app/controllers/applicants/employment_details_controller.rb
@@ -12,11 +12,10 @@ module Applicants
       @employment_detail = EmploymentDetail.new(employment_detail_params)
 
       if @employment_detail.valid?
-        @applicant.create_school!(school_params)
+        @employment_detail.applicant = @applicant
+        @employment_detail.save!
 
-        @applicant.create_application!(
-          application_date: Date.current,
-        )
+        @applicant.create_application!(application_date: Date.current)
 
         # TODO: Clean up data we've added to the session
         # session.delete('')
@@ -42,20 +41,6 @@ module Applicants
         :school_county,
         :school_postcode,
       )
-    end
-
-    def school_params
-      {
-        name: employment_detail_params["school_name"],
-        headteacher_name: employment_detail_params["school_headteacher_name"],
-        address_attributes: {
-          address_line_1: employment_detail_params["school_address_line_1"],
-          address_line_2: employment_detail_params["school_address_line_2"],
-          city: employment_detail_params["school_city"],
-          county: employment_detail_params["school_county"],
-          postcode: employment_detail_params["school_postcode"],
-        },
-      }
     end
   end
 end

--- a/app/controllers/applicants/employment_details_controller.rb
+++ b/app/controllers/applicants/employment_details_controller.rb
@@ -10,9 +10,12 @@ module Applicants
       @employment_detail = EmploymentDetail.new(employment_detail_params)
 
       if @employment_detail.valid?
-        @applicant = Applicant.create!(applicant_params)
+        @applicant = Applicant.find(session[:applicant_id])
         @applicant.create_school!(school_params)
-        @applicant.create_address!(address_params)
+
+        @applicant.create_application!(
+          application_date: Date.current,
+        )
 
         # TODO: Clean up data we've added to the session
         # session.delete('')
@@ -36,23 +39,6 @@ module Applicants
       )
     end
 
-    def applicant_params
-      {
-        application_route: session["application_route"],
-        given_name: session["personal_detail"]["given_name"],
-        family_name: session["personal_detail"]["family_name"],
-        email_address: session["personal_detail"]["email_address"],
-        phone_number: session["personal_detail"]["phone_number"],
-        date_of_birth: session["personal_detail"]["date_of_birth"],
-        sex: session["personal_detail"]["sex"],
-        nationality: session["personal_detail"]["nationality"],
-        passport_number: session["personal_detail"]["passport_number"],
-        subject: session["subject"],
-        visa_type: session["visa_type"],
-        date_of_entry: session["entry_date"],
-      }
-    end
-
     def school_params
       {
         name: employment_detail_params["school_name"],
@@ -64,18 +50,6 @@ module Applicants
           county: employment_detail_params["school_county"],
           postcode: employment_detail_params["school_postcode"],
         },
-      }
-    end
-
-    def address_params
-      {
-        addressable_id: @applicant.id,
-        addressable_type: "Applicant",
-        address_line_1: session["personal_detail"]["address_line_1"],
-        address_line_2: session["personal_detail"]["address_line_2"],
-        city: session["personal_detail"]["city"],
-        county: session["personal_detail"]["county"],
-        postcode: session["personal_detail"]["postcode"],
       }
     end
   end

--- a/app/controllers/applicants/employment_details_controller.rb
+++ b/app/controllers/applicants/employment_details_controller.rb
@@ -19,7 +19,7 @@ module Applicants
 
         # TODO: Clean up data we've added to the session
         # session.delete('')
-        redirect_to(submitted_path)
+        redirect_to(applicants_submission_path)
       else
         render(:new)
       end

--- a/app/controllers/applicants/employment_details_controller.rb
+++ b/app/controllers/applicants/employment_details_controller.rb
@@ -17,8 +17,6 @@ module Applicants
 
         Application.register_for_applicant!(@applicant)
 
-        # TODO: Clean up data we've added to the session
-        # session.delete('')
         redirect_to(applicants_submission_path)
       else
         render(:new)

--- a/app/controllers/applicants/employment_details_controller.rb
+++ b/app/controllers/applicants/employment_details_controller.rb
@@ -15,7 +15,7 @@ module Applicants
         @employment_detail.applicant = @applicant
         @employment_detail.save!
 
-        @applicant.create_application!(application_date: Date.current)
+        Application.register_for_applicant!(@applicant)
 
         # TODO: Clean up data we've added to the session
         # session.delete('')

--- a/app/controllers/applicants/employment_details_controller.rb
+++ b/app/controllers/applicants/employment_details_controller.rb
@@ -13,7 +13,7 @@ module Applicants
         @employment_detail.applicant = current_applicant
         @employment_detail.save!
 
-        Application.register_for_applicant!(current_applicant)
+        Application.initialise_for_applicant!(current_applicant)
 
         redirect_to(applicants_submission_path)
       else

--- a/app/controllers/applicants/personal_details_controller.rb
+++ b/app/controllers/applicants/personal_details_controller.rb
@@ -2,12 +2,6 @@
 
 module Applicants
   class PersonalDetailsController < ApplicationController
-    DOB_CONVERSION = {
-      "date_of_birth(3i)" => "day",
-      "date_of_birth(2i)" => "month",
-      "date_of_birth(1i)" => "year",
-    }.freeze
-
     def new
       @personal_detail = PersonalDetail.new
     end
@@ -47,5 +41,12 @@ module Applicants
         DOB_CONVERSION.key?(key) ? DOB_CONVERSION[key] : key
       end
     end
+
+    DOB_CONVERSION = {
+      "date_of_birth(3i)" => "day",
+      "date_of_birth(2i)" => "month",
+      "date_of_birth(1i)" => "year",
+    }.freeze
+    private_constant :DOB_CONVERSION
   end
 end

--- a/app/controllers/applicants/personal_details_controller.rb
+++ b/app/controllers/applicants/personal_details_controller.rb
@@ -11,7 +11,6 @@ module Applicants
 
       if @personal_detail.valid?
         applicant = @personal_detail.save!
-
         session[:applicant_id] = applicant.id
 
         redirect_to(new_applicants_employment_detail_path)

--- a/app/controllers/applicants/personal_details_controller.rb
+++ b/app/controllers/applicants/personal_details_controller.rb
@@ -16,21 +16,9 @@ module Applicants
       @personal_detail = PersonalDetail.new(personal_detail_params)
 
       if @personal_detail.valid?
-        session[:personal_detail] = {
-          "given_name" => @personal_detail.given_name,
-          "family_name" => @personal_detail.family_name,
-          "email_address" => @personal_detail.email_address,
-          "phone_number" => @personal_detail.phone_number,
-          "date_of_birth" => @personal_detail.date_of_birth,
-          "sex" => @personal_detail.sex,
-          "passport_number" => @personal_detail.passport_number,
-          "nationality" => @personal_detail.nationality,
-          "address_line_1" => @personal_detail.address_line_1,
-          "address_line_2" => @personal_detail.address_line_2,
-          "city" => @personal_detail.city,
-          "county" => @personal_detail.county,
-          "postcode" => @personal_detail.postcode,
-        }
+        applicant = @personal_detail.save!
+
+        session[:applicant_id] = applicant.id
 
         redirect_to(new_applicants_employment_detail_path)
       else

--- a/app/controllers/applicants/submissions_controller.rb
+++ b/app/controllers/applicants/submissions_controller.rb
@@ -2,6 +2,8 @@
 
 module Applicants
   class SubmissionsController < ApplicationController
-    def show; end
+    def show
+      @applicant = Applicant.find(session[:applicant_id])
+    end
   end
 end

--- a/app/controllers/applicants/submissions_controller.rb
+++ b/app/controllers/applicants/submissions_controller.rb
@@ -3,9 +3,7 @@
 module Applicants
   class SubmissionsController < ApplicationController
     def show
-      applicant = Applicant.find(session[:applicant_id])
-
-      @application = applicant.application
+      @application = current_applicant.application
     end
   end
 end

--- a/app/controllers/applicants/submissions_controller.rb
+++ b/app/controllers/applicants/submissions_controller.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module Applicants
+  class SubmissionsController < ApplicationController
+    def show; end
+  end
+end

--- a/app/controllers/applicants/submissions_controller.rb
+++ b/app/controllers/applicants/submissions_controller.rb
@@ -3,7 +3,9 @@
 module Applicants
   class SubmissionsController < ApplicationController
     def show
-      @applicant = Applicant.find(session[:applicant_id])
+      applicant = Applicant.find(session[:applicant_id])
+
+      @application = applicant.application
     end
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -9,6 +9,11 @@ class ApplicationController < ActionController::Base
     session["application_route"]
   end
 
+  def current_applicant
+    Applicant.find(session[:applicant_id])
+  end
+  helper_method :current_applicant
+
   def check_teacher!
     return unless application_route != "teacher"
 

--- a/app/models/applicant.rb
+++ b/app/models/applicant.rb
@@ -32,8 +32,11 @@ class Applicant < ApplicationRecord
   has_one :applicant_progress, dependent: :destroy
 
   has_one :address, as: :addressable, dependent: :destroy
+  accepts_nested_attributes_for :address
 
   belongs_to :school, dependent: :destroy, optional: true
+
+  has_one :application, dependent: :destroy
 
   delegate \
     :initial_checks_completed_at,

--- a/app/models/applicants/employment_detail.rb
+++ b/app/models/applicants/employment_detail.rb
@@ -9,12 +9,27 @@ module Applicants
                   :school_address_line_2,
                   :school_city,
                   :school_county,
-                  :school_postcode
+                  :school_postcode,
+                  :applicant
 
     validates :school_name, presence: true
     validates :school_headteacher_name, presence: true
     validates :school_address_line_1, presence: true
     validates :school_city, presence: true
     validates :school_postcode, presence: true, postcode: true
+
+    def save!
+      applicant.create_school!(
+        name: school_name,
+        headteacher_name: school_headteacher_name,
+        address_attributes: {
+          address_line_1: school_address_line_1,
+          address_line_2: school_address_line_2,
+          city: school_city,
+          county: school_county,
+          postcode: school_postcode,
+        },
+      )
+    end
   end
 end

--- a/app/models/applicants/personal_detail.rb
+++ b/app/models/applicants/personal_detail.rb
@@ -35,6 +35,27 @@ module Applicants
       InvalidDate.new(day:, month:, year:)
     end
 
+    def save!
+      Applicant.create!(
+        given_name: given_name,
+        family_name: family_name,
+        email_address: email_address,
+        phone_number: phone_number,
+        date_of_birth: date_of_birth,
+        sex: sex,
+        passport_number: passport_number,
+        nationality: nationality,
+        address_attributes: {
+          address_line_1:,
+          address_line_2:,
+          city:,
+          county:,
+          postcode:,
+
+        },
+      )
+    end
+
   private
 
     def date_of_birth_not_in_future

--- a/app/models/applicants/personal_detail.rb
+++ b/app/models/applicants/personal_detail.rb
@@ -51,7 +51,6 @@ module Applicants
           city:,
           county:,
           postcode:,
-
         },
       )
     end

--- a/app/models/application.rb
+++ b/app/models/application.rb
@@ -20,7 +20,7 @@ class Application < ApplicationRecord
 
   validates :application_date, presence: true
 
-  def self.register_for_applicant!(applicant)
+  def self.initialise_for_applicant!(applicant)
     create!(
       applicant: applicant,
       application_date: Date.current.to_s,

--- a/app/models/application.rb
+++ b/app/models/application.rb
@@ -3,7 +3,7 @@
 # Table name: applications
 #
 #  id               :bigint           not null, primary key
-#  application_date :string           not null
+#  application_date :date             not null
 #  urn              :string           not null
 #  created_at       :datetime         not null
 #  updated_at       :datetime         not null

--- a/app/models/application.rb
+++ b/app/models/application.rb
@@ -16,6 +16,7 @@
 class Application < ApplicationRecord
   belongs_to :applicant
 
+  serialize :urn, Urn
+
   validates :application_date, presence: true
-  validates :urn, presence: true
 end

--- a/app/models/application.rb
+++ b/app/models/application.rb
@@ -1,0 +1,21 @@
+# == Schema Information
+#
+# Table name: applications
+#
+#  id               :bigint           not null, primary key
+#  application_date :string           not null
+#  urn              :string           not null
+#  created_at       :datetime         not null
+#  updated_at       :datetime         not null
+#  applicant_id     :bigint           not null
+#
+# Foreign Keys
+#
+#  fk_rails_...  (applicant_id => applicants.id)
+#
+class Application < ApplicationRecord
+  belongs_to :applicant
+
+  validates :application_date, presence: true
+  validates :urn, presence: true
+end

--- a/app/models/application.rb
+++ b/app/models/application.rb
@@ -19,4 +19,11 @@ class Application < ApplicationRecord
   serialize :urn, Urn
 
   validates :application_date, presence: true
+
+  def self.register_for_applicant!(applicant)
+    create!(
+      applicant: applicant,
+      application_date: Date.current.to_s,
+    )
+  end
 end

--- a/app/models/urn.rb
+++ b/app/models/urn.rb
@@ -7,7 +7,7 @@
 #
 # Example:
 #
-#   Urn.new.value # => "IRP1A2B3C"
+#   Urn.new.value # => "IRP 1A2B3C"
 #
 # As it implements `.dump` and `.load`, it can be used with `serialize` as
 # an Active Model. It can be included as an attribute in your model
@@ -26,8 +26,8 @@
 #   your_model.reload
 #   puts your_model.urn.value
 #
-#   Urn.dump(Urn.new) # => "IRPGA2B3C"
-#   Urn.load("IRPGA2B3C") # => #<Urn:0x00000001154a9a78 @value="IRPGA2B3C">
+#   Urn.dump(Urn.new) # => "IRP GA2B3C"
+#   Urn.load("IRP GA2B3C") # => #<Urn:0x00000001154a9a78 @value="IRP GA2B3C">
 #
 #  Duplications
 #    Total number of combinations is: 26^6 = 308,915,776 ~ 310M

--- a/app/models/urn.rb
+++ b/app/models/urn.rb
@@ -34,8 +34,8 @@
 class Urn
   attr_reader :value
 
-  def initialize(value:)
-    @value = value
+  def initialize(value = nil)
+    @value = value || Urn.generate_urn
   end
 
   def self.dump(urn)
@@ -43,7 +43,7 @@ class Urn
   end
 
   def self.load(value)
-    Urn.new(value: value || generate_urn)
+    Urn.new(value)
   end
 
   def ==(other)

--- a/app/models/urn.rb
+++ b/app/models/urn.rb
@@ -58,7 +58,7 @@ class Urn
   private_constant :CHARSET, :PREFIX, :LENGTH
 
   def self.generate_urn
-    PREFIX + " " + Array.new(LENGTH) { CHARSET.sample }.join
+    "#{PREFIX} " + Array.new(LENGTH) { CHARSET.sample }.join
   end
 
   private_methods :generate_urn

--- a/app/models/urn.rb
+++ b/app/models/urn.rb
@@ -27,23 +27,29 @@
 #   puts your_model.urn.value
 #
 #   Urn.dump(Urn.new) # => "IRPGA2B3C"
-#   Urn.load("IRPGA2B3C") # => "IRPGA2B3C"
+#   Urn.load("IRPGA2B3C") # => #<Urn:0x00000001154a9a78 @value="IRPGA2B3C">
 #
 #  Duplications
 #    Total number of combinations is: 26^6 = 308,915,776 ~ 310M
 class Urn
   attr_reader :value
 
-  def initialize
-    @value = Urn.generate_urn
+  def initialize(value:)
+    @value = value
   end
 
-  def self.dump(value)
-    value
+  def self.dump(urn)
+    urn.value
   end
 
   def self.load(value)
-    value || generate_urn
+    Urn.new(value: value || generate_urn)
+  end
+
+  def ==(other)
+    return false unless other.is_a?(Urn)
+
+    @value == other.value
   end
 
   CHARSET = %w[A B C D E F H J K L M N P R S T U V 2 3 4 5 6 7 8 9].freeze
@@ -52,7 +58,7 @@ class Urn
   private_constant :CHARSET, :PREFIX, :LENGTH
 
   def self.generate_urn
-    PREFIX + Array.new(LENGTH) { CHARSET.sample }.join
+    PREFIX + " " + Array.new(LENGTH) { CHARSET.sample }.join
   end
 
   private_methods :generate_urn

--- a/app/views/applicants/submissions/show.html.erb
+++ b/app/views/applicants/submissions/show.html.erb
@@ -10,7 +10,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">
     <p class="govuk-body">
-      Your details have been submitted and will now be checked by the
+     Your details have been submitted and will now be checked by the
       Department for Education and the Home Office.
     </p>
 

--- a/app/views/applicants/submissions/show.html.erb
+++ b/app/views/applicants/submissions/show.html.erb
@@ -7,7 +7,7 @@
             Application complete
           </h1>
           <div class="govuk-panel__body">
-            Your reference number<br><strong><%= @applicant.application.urn.value %></strong>
+            Your reference number<br><strong><%= @application.urn.value %></strong>
           </div>
         </div>
         <h2 class="govuk-heading-m">What happens next</h2>

--- a/app/views/applicants/submissions/show.html.erb
+++ b/app/views/applicants/submissions/show.html.erb
@@ -1,28 +1,40 @@
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds-from-desktop">
-    <h1 class="govuk-heading-l">
-      Thank you for completing the international relocation payment application
-      form
-    </h1>
-  </div>
+<div class="govuk-width-container">
+  <main class="govuk-main-wrapper govuk-main-wrapper--l" id="main-content" role="main">
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-two-thirds">
+        <div class="govuk-panel govuk-panel--confirmation">
+          <h1 class="govuk-panel__title">
+            Application complete
+          </h1>
+          <div class="govuk-panel__body">
+            Your reference number<br><strong><%= @applicant.application.urn.value %></strong>
+          </div>
+        </div>
+        <h2 class="govuk-heading-m">What happens next</h2>
+        <p class="govuk-body">
+          You have successfully submitted your international relocation payment application form and will receive a
+          confirmation email from the Department for Education (Dfe).
+        </p>
+
+        <p class="govuk-body">
+          Keep this safe, as you will need it if your application is successful.
+        </p>
+
+        <p class="govuk-body">
+          We'll let you know the outcome of your application as soon as we've checked your eligibility. If you are eligible,
+          you will be paid around the end of your first term of training or employment.
+        </p>
+
+        <p class="govuk-body">
+          For help, you can email us at
+          <%= govuk_link_to("teach.inengland@education.gov.uk", "mailto:teach.inengland@education.gov.uk") %>.
+        </p>
+      </div>
+    </div>
+  </main>
 </div>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">
-    <p class="govuk-body">
-     Your details have been submitted and will now be checked by the
-      Department for Education and the Home Office.
-    </p>
-
-    <p class="govuk-body">
-      We will let you know when we have completed our checks. If you are
-      eligible for the international relocation payment, you’ll receive the
-      money around the end of your first school term of employment.
-    </p>
-
-    <p class="govuk-body">
-      For help, you can email us at
-      <%= govuk_link_to("teach.inengland@education.gov.uk", "mailto:teach.inengland@education.gov.uk")%>.
-    </p>
   </div>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,7 +6,6 @@ Rails.application.routes.draw do
   # Defines the root path route ("/")
   root to: "pages#start"
 
-  get "/submitted", to: "pages#submitted"
   get "/ineligible", to: "pages#ineligible"
 
   namespace :applicants do
@@ -21,6 +20,7 @@ Rails.application.routes.draw do
     resources :personal_details, only: %i[new create]
     resources :employment_details, only: %i[new create]
     resources :salaried_course_details, only: %i[new create]
+    resource :submission, only: %i[show]
   end
 
   # TODO: route constraint, only signed-in admins should be able to access

--- a/db/migrate/20230619112449_create_applications.rb
+++ b/db/migrate/20230619112449_create_applications.rb
@@ -1,7 +1,7 @@
 class CreateApplications < ActiveRecord::Migration[7.0]
   def change
     create_table :applications do |t|
-      t.string :application_date, null: false
+      t.date :application_date, null: false
       t.string :urn, null: false
       t.references :applicant, null: false, foreign_key: true
 

--- a/db/migrate/20230619112449_create_applications.rb
+++ b/db/migrate/20230619112449_create_applications.rb
@@ -1,0 +1,11 @@
+class CreateApplications < ActiveRecord::Migration[7.0]
+  def change
+    create_table :applications do |t|
+      t.string :application_date, null: false
+      t.string :urn, null: false
+      t.references :applicant, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_06_15_132013) do
+ActiveRecord::Schema[7.0].define(version: 2023_06_19_112449) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -58,6 +58,15 @@ ActiveRecord::Schema[7.0].define(version: 2023_06_15_132013) do
     t.index ["school_id"], name: "index_applicants_on_school_id"
   end
 
+  create_table "applications", force: :cascade do |t|
+    t.string "application_date", null: false
+    t.string "urn", null: false
+    t.bigint "applicant_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["applicant_id"], name: "index_applications_on_applicant_id"
+  end
+
   create_table "schools", force: :cascade do |t|
     t.string "postcode"
     t.string "name"
@@ -68,4 +77,5 @@ ActiveRecord::Schema[7.0].define(version: 2023_06_15_132013) do
 
   add_foreign_key "applicant_progresses", "applicants"
   add_foreign_key "applicants", "schools"
+  add_foreign_key "applications", "applicants"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -59,7 +59,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_06_19_112449) do
   end
 
   create_table "applications", force: :cascade do |t|
-    t.string "application_date", null: false
+    t.date "application_date", null: false
     t.string "urn", null: false
     t.bigint "applicant_id", null: false
     t.datetime "created_at", null: false

--- a/spec/factories/applications.rb
+++ b/spec/factories/applications.rb
@@ -3,7 +3,7 @@
 # Table name: applications
 #
 #  id               :bigint           not null, primary key
-#  application_date :string           not null
+#  application_date :date             not null
 #  urn              :string           not null
 #  created_at       :datetime         not null
 #  updated_at       :datetime         not null

--- a/spec/factories/applications.rb
+++ b/spec/factories/applications.rb
@@ -1,0 +1,22 @@
+# == Schema Information
+#
+# Table name: applications
+#
+#  id               :bigint           not null, primary key
+#  application_date :string           not null
+#  urn              :string           not null
+#  created_at       :datetime         not null
+#  updated_at       :datetime         not null
+#  applicant_id     :bigint           not null
+#
+# Foreign Keys
+#
+#  fk_rails_...  (applicant_id => applicants.id)
+#
+FactoryBot.define do
+  factory :application do
+    application_date { Faker::Date.in_date_period }
+    urn { "IRP #{Faker::Number.number(digits: 6)} LT" }
+    applicant
+  end
+end

--- a/spec/factories/applications.rb
+++ b/spec/factories/applications.rb
@@ -16,7 +16,7 @@
 FactoryBot.define do
   factory :application do
     application_date { Faker::Date.in_date_period }
-    urn { "IRP #{Faker::Number.number(digits: 6)} LT" }
+    urn { Urn.new }
     applicant
   end
 end

--- a/spec/features/teacher_route_completing_the_form_spec.rb
+++ b/spec/features/teacher_route_completing_the_form_spec.rb
@@ -19,7 +19,7 @@ describe "teacher route: completing the form" do
       and_i_enter_my_personal_details
       and_i_enter_my_employment_details
 
-      expect(page).to have_text("Thank you for completing")
+      expect(page).to have_text("Application complete")
     end
   end
 

--- a/spec/features/trainee_route_completing_the_form_spec.rb
+++ b/spec/features/trainee_route_completing_the_form_spec.rb
@@ -17,7 +17,7 @@ describe "trainee route: completing the form" do
       and_i_enter_my_personal_details
       and_i_enter_my_employment_details
 
-      expect(page).to have_text("Thank you for completing the international relocation payment application form")
+      expect(page).to have_text("Application complete")
     end
 
     def and_i_complete_the_trainee_employment_conditions

--- a/spec/models/address_spec.rb
+++ b/spec/models/address_spec.rb
@@ -1,5 +1,20 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: addresses
+#
+#  id               :bigint           not null, primary key
+#  address_line_1   :string
+#  address_line_2   :string
+#  addressable_type :string           not null
+#  city             :string
+#  county           :string
+#  postcode         :string
+#  created_at       :datetime         not null
+#  updated_at       :datetime         not null
+#  addressable_id   :bigint           not null
+#
 require "rails_helper"
 
 describe Address do

--- a/spec/models/applicants/employment_detail_spec.rb
+++ b/spec/models/applicants/employment_detail_spec.rb
@@ -8,11 +8,43 @@ module Applicants
 
     include_examples "a valid UK postcode", described_class, :school_postcode
 
-    subject { described_class.new(params) }
+    subject(:model) { described_class.new(params) }
 
     describe "validations" do
       it { is_expected.to validate_presence_of(:school_name) }
       it { is_expected.to validate_presence_of(:school_headteacher_name) }
+    end
+
+    describe "save!" do
+      let(:params) do
+        {
+          school_name: "Test School",
+          school_headteacher_name: "Test Headteacher",
+          school_address_line_1: "Test Address Line 1",
+          school_address_line_2: "Test Address Line 2",
+          school_city: "Test City",
+          school_county: "Test County",
+          school_postcode: "SE2 0BA",
+        }
+      end
+
+      before do
+        model.applicant = FactoryBot.create :applicant
+      end
+
+      it "creates a school" do
+        expect { model.save! }.to change(School, :count).by(1)
+      end
+
+      it "creates an address" do
+        expect { model.save! }.to change(Address, :count).by(1)
+      end
+
+      it "links the school with the address" do
+        model.save!
+
+        expect(model.applicant.school.address).to eq(Address.last)
+      end
     end
   end
 end

--- a/spec/models/applicants/employment_detail_spec.rb
+++ b/spec/models/applicants/employment_detail_spec.rb
@@ -29,7 +29,7 @@ module Applicants
       end
 
       before do
-        model.applicant = FactoryBot.create :applicant
+        model.applicant = create :applicant
       end
 
       it "creates a school" do

--- a/spec/models/applicants/personal_detail_spec.rb
+++ b/spec/models/applicants/personal_detail_spec.rb
@@ -66,6 +66,10 @@ module Applicants
 
           expect(Applicant.last.address).to eq(Address.last)
         end
+
+        it "returns an applicant" do
+          expect(model.save!).to be_a(Applicant)
+        end
       end
 
       describe "date_of_birth" do

--- a/spec/models/applicants/personal_detail_spec.rb
+++ b/spec/models/applicants/personal_detail_spec.rb
@@ -30,6 +30,44 @@ module Applicants
       include_examples "a valid UK postcode", described_class
       include_examples "validates phone number with international prefix", described_class, :phone_number
 
+      describe "save!" do
+        let(:params) do
+          {
+            given_name: "John",
+            family_name: "Smith",
+            email_address: "john@email.com",
+            phone_number: "07777777777",
+            day: "01",
+            month: "01",
+            year: "2000",
+            sex: "Male",
+            passport_number: "123456789",
+            nationality: "British",
+            address_line_1: "1 High Street",
+            address_line_2: "Flat 1",
+            city: "London",
+            county: "London",
+            postcode: "SW1A 1AA",
+          }
+        end
+
+        subject(:model) { described_class.new(params) }
+
+        it "creates an applicant" do
+          expect { model.save! }.to change(Applicant, :count).by(1)
+        end
+
+        it "creates an address" do
+          expect { model.save! }.to change(Address, :count).by(1)
+        end
+
+        it "links the address and the applicant" do
+          model.save!
+
+          expect(Applicant.last.address).to eq(Address.last)
+        end
+      end
+
       describe "date_of_birth" do
         context "when date_of_birth is invalid" do
           let(:params) { { day: "31", month: "02", year: "2000" } }

--- a/spec/models/application_spec.rb
+++ b/spec/models/application_spec.rb
@@ -1,0 +1,21 @@
+# == Schema Information
+#
+# Table name: applications
+#
+#  id               :bigint           not null, primary key
+#  application_date :string           not null
+#  urn              :string           not null
+#  created_at       :datetime         not null
+#  updated_at       :datetime         not null
+#  applicant_id     :bigint           not null
+#
+# Foreign Keys
+#
+#  fk_rails_...  (applicant_id => applicants.id)
+#
+require "rails_helper"
+
+RSpec.describe Application do
+  it { is_expected.to validate_presence_of(:urn) }
+  it { is_expected.to validate_presence_of(:application_date) }
+end

--- a/spec/models/application_spec.rb
+++ b/spec/models/application_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe Application do
     end
 
     it "starts with IRP" do
-      expect(application.urn.value).to match(/\AIRP [ABCFHJKLMNPRSTUV23456789]{6}\z/)
+      expect(application.urn.value).to match(/\AIRP [ABCDEFHJKLMNPRSTUV23456789]{6}\z/)
     end
   end
 end

--- a/spec/models/application_spec.rb
+++ b/spec/models/application_spec.rb
@@ -30,29 +30,29 @@ RSpec.describe Application do
     end
   end
 
-  describe "#register_for_applicant!" do
+  describe "#initialise_for_applicant!" do
     subject(:klass) { described_class }
 
     let(:applicant) { create(:applicant) }
 
     it "returns an application" do
-      expect(klass.register_for_applicant!(applicant)).to be_a(described_class)
+      expect(klass.initialise_for_applicant!(applicant)).to be_a(described_class)
     end
 
     it "sets the applicant" do
-      klass.register_for_applicant!(applicant)
+      klass.initialise_for_applicant!(applicant)
 
       expect(applicant.application).to be_present
     end
 
     it "sets the application date" do
-      application = klass.register_for_applicant!(applicant)
+      application = klass.initialise_for_applicant!(applicant)
 
       expect(application.application_date).to eq(Date.current)
     end
 
     it "sets the urn" do
-      application = klass.register_for_applicant!(applicant)
+      application = klass.initialise_for_applicant!(applicant)
 
       expect(application.urn).to be_present
     end

--- a/spec/models/application_spec.rb
+++ b/spec/models/application_spec.rb
@@ -29,4 +29,32 @@ RSpec.describe Application do
       expect(application.urn.value).to match(/\AIRP [ABCDEFHJKLMNPRSTUV23456789]{6}\z/)
     end
   end
+
+  describe "#register_for_applicant!" do
+    subject(:klass) { described_class }
+
+    let(:applicant) { FactoryBot.create(:applicant) }
+
+    it "returns an application" do
+      expect(klass.register_for_applicant!(applicant)).to be_a(described_class)
+    end
+
+    it "sets the applicant" do
+      klass.register_for_applicant!(applicant)
+
+      expect(applicant.application).to be_present
+    end
+
+    it "sets the application date" do
+      application = klass.register_for_applicant!(applicant)
+
+      expect(application.application_date).to eq(Date.current)
+    end
+
+    it "sets the urn" do
+      application = klass.register_for_applicant!(applicant)
+
+      expect(application.urn).to be_present
+    end
+  end
 end

--- a/spec/models/application_spec.rb
+++ b/spec/models/application_spec.rb
@@ -3,7 +3,7 @@
 # Table name: applications
 #
 #  id               :bigint           not null, primary key
-#  application_date :string           not null
+#  application_date :date             not null
 #  urn              :string           not null
 #  created_at       :datetime         not null
 #  updated_at       :datetime         not null

--- a/spec/models/application_spec.rb
+++ b/spec/models/application_spec.rb
@@ -16,6 +16,17 @@
 require "rails_helper"
 
 RSpec.describe Application do
-  it { is_expected.to validate_presence_of(:urn) }
   it { is_expected.to validate_presence_of(:application_date) }
+
+  describe "#urn" do
+    subject(:application) { described_class.new }
+
+    it "is not blank on instantiation" do
+      expect(application.urn).to be_present
+    end
+
+    it "starts with IRP" do
+      expect(application.urn.value).to match(/\AIRP [ABCFHJKLMNPRSTUV23456789]{6}\z/)
+    end
+  end
 end

--- a/spec/models/application_spec.rb
+++ b/spec/models/application_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe Application do
   describe "#register_for_applicant!" do
     subject(:klass) { described_class }
 
-    let(:applicant) { FactoryBot.create(:applicant) }
+    let(:applicant) { create(:applicant) }
 
     it "returns an application" do
       expect(klass.register_for_applicant!(applicant)).to be_a(described_class)

--- a/spec/models/school_spec.rb
+++ b/spec/models/school_spec.rb
@@ -1,5 +1,16 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: schools
+#
+#  id               :bigint           not null, primary key
+#  headteacher_name :string
+#  name             :string
+#  postcode         :string
+#  created_at       :datetime         not null
+#  updated_at       :datetime         not null
+#
 require "rails_helper"
 
 describe School do

--- a/spec/models/urn_spec.rb
+++ b/spec/models/urn_spec.rb
@@ -2,7 +2,7 @@
 require "rails_helper"
 
 RSpec.describe Urn do
-  subject(:urn) { described_class.new }
+  subject(:urn) { described_class.load("IRP 123456") }
 
   it "has a value" do
     expect(urn.value).to be_present
@@ -13,22 +13,22 @@ RSpec.describe Urn do
   end
 
   it "generates a Urn with a length of 8" do
-    expect(urn.value.length).to eq(9)
+    expect(urn.value.length).to eq(10)
   end
 
   it "generates a Urn with a suffix of 6 characters" do
-    expect(urn.value[3..].length).to eq(6)
+    expect(urn.value[4..].length).to eq(6)
   end
 
   it "generates a Urn with a suffix of only characters in the CHARSET" do
     charset = %w[A B C D E F H J K L M N P R S T U V 0 1 2 3 4 5 6 7 8 9]
 
-    expect(urn.value[3..].chars).to all(be_in(charset))
+    expect(urn.value[4..].chars).to all(be_in(charset))
   end
 
   describe ".dump" do
     it "returns the given value" do
-      expect(described_class.dump("IRPG2345")).to eq("IRPG2345")
+      expect(described_class.dump(described_class.new(value: "IRPG2345"))).to eq("IRPG2345")
     end
   end
 
@@ -38,7 +38,7 @@ RSpec.describe Urn do
     end
 
     it "returns the given value when `value` is not `nil`" do
-      expect(described_class.load("IRPG2345")).to eq("IRPG2345")
+      expect(described_class.load("IRPG2345")).to eq(described_class.new(value: "IRPG2345"))
     end
   end
 end

--- a/spec/models/urn_spec.rb
+++ b/spec/models/urn_spec.rb
@@ -38,13 +38,13 @@ RSpec.describe Urn do
 
   describe ".dump" do
     it "returns the given value" do
-      expect(described_class.dump(described_class.new("IRPG2345"))).to eq("IRPG2345")
+      expect(described_class.dump(described_class.new("IRP G2345"))).to eq("IRP G2345")
     end
   end
 
   describe ".load" do
     it "returns the given value when `value` is not `nil`" do
-      expect(described_class.load("IRPG2345")).to eq(described_class.new("IRPG2345"))
+      expect(described_class.load("IRP G2345")).to eq(described_class.new("IRP G2345"))
     end
   end
 end

--- a/spec/models/urn_spec.rb
+++ b/spec/models/urn_spec.rb
@@ -2,43 +2,49 @@
 require "rails_helper"
 
 RSpec.describe Urn do
-  subject(:urn) { described_class.load("IRP 123456") }
+  context "When a value is given" do
+    subject(:urn) { described_class.new("IRP 123456") }
 
-  it "has a value" do
-    expect(urn.value).to be_present
+    it "has a value" do
+      expect(urn.value).to be_present
+    end
+
+    it "generates a Urn with a prefix of 'IRP'" do
+      expect(urn.value).to start_with("IRP")
+    end
+
+    it "generates a Urn with a length of 8" do
+      expect(urn.value.length).to eq(10)
+    end
+
+    it "generates a Urn with a suffix of 6 characters" do
+      expect(urn.value[4..].length).to eq(6)
+    end
+
+    it "generates a Urn with a suffix of only characters in the CHARSET" do
+      charset = %w[A B C D E F H J K L M N P R S T U V 0 1 2 3 4 5 6 7 8 9]
+
+      expect(urn.value[4..].chars).to all(be_in(charset))
+    end
   end
 
-  it "generates a Urn with a prefix of 'IRP'" do
-    expect(urn.value).to start_with("IRP")
-  end
+  context "When a value is not given" do
+    subject(:urn) { described_class.new }
 
-  it "generates a Urn with a length of 8" do
-    expect(urn.value.length).to eq(10)
-  end
-
-  it "generates a Urn with a suffix of 6 characters" do
-    expect(urn.value[4..].length).to eq(6)
-  end
-
-  it "generates a Urn with a suffix of only characters in the CHARSET" do
-    charset = %w[A B C D E F H J K L M N P R S T U V 0 1 2 3 4 5 6 7 8 9]
-
-    expect(urn.value[4..].chars).to all(be_in(charset))
+    it "has a value" do
+      expect(urn.value).to be_present
+    end
   end
 
   describe ".dump" do
     it "returns the given value" do
-      expect(described_class.dump(described_class.new(value: "IRPG2345"))).to eq("IRPG2345")
+      expect(described_class.dump(described_class.new("IRPG2345"))).to eq("IRPG2345")
     end
   end
 
   describe ".load" do
-    it "generates a new Urn when `value` is `nil`" do
-      expect(described_class.load(nil)).not_to be_nil
-    end
-
     it "returns the given value when `value` is not `nil`" do
-      expect(described_class.load("IRPG2345")).to eq(described_class.new(value: "IRPG2345"))
+      expect(described_class.load("IRPG2345")).to eq(described_class.new("IRPG2345"))
     end
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -77,3 +77,7 @@ Shoulda::Matchers.configure do |config|
     with.library :rails
   end
 end
+
+RSpec.configure do |config|
+  config.include FactoryBot::Syntax::Methods
+end

--- a/spec/requests/question_for_employment_details_spec.rb
+++ b/spec/requests/question_for_employment_details_spec.rb
@@ -70,7 +70,7 @@ module Applicants
       # The current implementation users the user session to store attributes, which
       # is not ideal and should be changed next. For now we are stubbing the session
       # to return the applicant details.
-      applicant = FactoryBot.create(:applicant)
+      applicant = create(:applicant)
       allow_any_instance_of(EmploymentDetailsController).to receive(:session).and_return({
         applicant_id: applicant.id,
       })

--- a/spec/requests/question_for_employment_details_spec.rb
+++ b/spec/requests/question_for_employment_details_spec.rb
@@ -25,7 +25,7 @@ module Applicants
         it "redirects to the submitted path" do
           post "/applicants/employment_details", params: valid_params
 
-          expect(response).to redirect_to(submitted_path)
+          expect(response).to redirect_to(applicants_submission_path)
         end
 
         it "creates a School" do

--- a/spec/requests/question_for_employment_details_spec.rb
+++ b/spec/requests/question_for_employment_details_spec.rb
@@ -28,11 +28,6 @@ module Applicants
           expect(response).to redirect_to(submitted_path)
         end
 
-        it "creates an Applicant record" do
-          expect { post "/applicants/employment_details", params: valid_params }
-            .to change(Applicant, :count).by(1)
-        end
-
         it "creates a School" do
           expect { post "/applicants/employment_details", params: valid_params }
             .to change(School, :count).by(1)
@@ -40,19 +35,13 @@ module Applicants
 
         it "creates an Applicant Address" do
           expect { post "/applicants/employment_details", params: valid_params }
-            .to change(Address, :count).by(2)
+            .to change(Address, :count).by(1)
         end
 
         it "links the applicant with the school" do
           post "/applicants/employment_details", params: valid_params
 
           expect(Applicant.last.school).to eq(School.last)
-        end
-
-        it "links the applicant with the address" do
-          post "/applicants/employment_details", params: valid_params
-
-          expect(Applicant.last.address).to eq(Address.last)
         end
       end
 
@@ -81,29 +70,11 @@ module Applicants
       # The current implementation users the user session to store attributes, which
       # is not ideal and should be changed next. For now we are stubbing the session
       # to return the applicant details.
+      applicant = FactoryBot.create(:applicant)
       allow_any_instance_of(EmploymentDetailsController).to receive(:session).and_return({
-        "application_route" => "teacher",
-        "personal_detail" => {
-          "given_name" => "John",
-          "family_name" => "Doe",
-          "email_address" => "john@email.com",
-          "phone_number" => "07700 900 982",
-          "date_of_birth" => "10-12-2010",
-          "sex" => "Male",
-          "nationality" => "Spanish",
-          "passport_number" => "123456789",
-          "subject" => "Maths",
-          "visa_type" => "Tier 2",
-          "entry_date" => "1-8-2023",
-          "address_line_1" => "123 Fake Street",
-          "address_line_2" => "Fake Town",
-          "city" => "London",
-          "county" => "London",
-          "postcode" => "E1 8QS",
-        },
+        applicant_id: applicant.id,
       })
     end
-
     # rubocop:enable RSpec/AnyInstance
   end
 end

--- a/spec/requests/question_for_personal_details_spec.rb
+++ b/spec/requests/question_for_personal_details_spec.rb
@@ -1,0 +1,61 @@
+require "rails_helper"
+
+module Applicants
+  RSpec.describe "Question for Personal details" do
+    describe "POST create" do
+      let(:valid_params) do
+        {
+          applicants_personal_detail: {
+            "given_name" => "John",
+            "family_name" => "Doe",
+            "email_address" => "john@email.com",
+            "phone_number" => "07702496000",
+            "sex" => "male",
+            "passport_number" => "123456789",
+            "nationality" => "British",
+            "address_line_1" => "7 McLeud",
+            "address_line_2" => "second line",
+            "city" => "London",
+            "county" => "County",
+            "postcode" => "E1 8QS",
+            "date_of_birth(3i)" => "1",
+            "date_of_birth(2i)" => "1",
+            "date_of_birth(1i)" => "1990",
+          },
+        }
+      end
+
+      context "with valid params" do
+        it "redirects to the employment details path" do
+          post "/applicants/personal_details", params: valid_params
+
+          expect(response).to redirect_to(new_applicants_employment_detail_path)
+        end
+
+        it "creates an Applicant" do
+          expect {
+            post "/applicants/personal_details", params: valid_params
+          }.to change(Applicant, :count).by(1)
+        end
+      end
+
+      context "with invalid params" do
+        let(:invalid) do
+          {
+            applicants_personal_detail: {
+              "school_name" => "Alexander McLeod Primary School",
+              "school_postcode" => "E1 8QS",
+              "school_headteacher_name" => "Mr. Headteacher",
+            },
+          }
+        end
+
+        it "renders the new template" do
+          post "/applicants/personal_details", params: invalid
+
+          expect(response.body).to include("Personal information")
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Trello Card Link

https://trello.com/c/fsy6rp4P/72-teacher-route-exit-page-copy-application-criteria-is-fulfilled
https://trello.com/c/DfypaSU8/71-trainee-exit-page-copy-application-criteria-is-fulfilled
https://trello.com/c/acwINfog/32-m-generate-urn-for-applications-on-submission

## Description

Add the exit page for trainee and teachers. Both routes use the same copy for the content. I have used the [GOV.UK guidelines for Applications](https://design-system.service.gov.uk/patterns/confirmation-pages/).

## Technical notes

1. Introduces a fix in 89e990e44502b52d211b8d2f3e41a3db93e81398 for #63 because I didn't wrap the value with the `Urn` class to get the most of encapsulation.
2. Introduces a new `request` test for the Personal Details question. This is now needed because I made some changes to how data is persisted.
3. Introduces the `Application` model following up #73. Extracting this domain model enables an easy location for the `urn` property that is displayed on the exit page.
4. In 1f8ed820699118a8b00c566a8f31908320bd894c introduces a controller for rendering the exit page. This enables rendering the `urn` for the application in a consistent way with the other questions.
5. It moves persisting attributes out of the controllers for: personal details and employment details. I have moved them into a `save!` method at the domain level. As suggested in https://github.com/DFE-Digital/international-teacher-relocation-payment/pull/70#discussion_r1234018276, it is a good thing to move into the `forms` domain folder, but I would rather doing it with all the classes and not with two in a single PR for consistency. I will do at a later stage as this PR is too big to include those changes.
6. It leverages ActiveRecord persistence and [dries-up controllers](https://github.com/DFE-Digital/international-teacher-relocation-payment/compare/exit-page-application-model?expand=1#diff-171fa0c697ee861041d20cf7716741b0f3e4ed647893a0379e5ce9031402ea69L38-L80) using the session only for the `applicant_id`. 


## Screenshots

<img width="690" alt="image" src="https://github.com/DFE-Digital/international-teacher-relocation-payment/assets/134513241/d9c0e504-8c1e-45aa-919b-a2aabff0c0ed">