### PR TITLE
Fix typo on Visa name

### DIFF
--- a/app/models/applicants/visa.rb
+++ b/app/models/applicants/visa.rb
@@ -7,7 +7,7 @@ module Applicants
 
     VISA_OPTIONS = [
       "Afghan Relocations and Assistance Policy",
-      "Afhgan citizens resettlement scheme",
+      "Afghan citizens resettlement scheme",
       "British National (Overseas) visa",
       "Family visa",
       "High Potential Individual visa",


### PR DESCRIPTION
## Trello card

https://trello.com/c/O4orwiAb/78-teacher-route-add-other-to-visa-option-exit-application-if-selected

## Description

Fixes typo with `Afghan citizens resettlement schema` Visa.

<img width="539" alt="image" src="https://github.com/DFE-Digital/international-teacher-relocation-payment/assets/134513241/c9dd69a1-2f16-4fe8-80ff-a161f7fb50bd">
