### PR TITLE
Add start contract question to trainees

### DIFF
--- a/app/controllers/applicants/contract_start_dates_controller.rb
+++ b/app/controllers/applicants/contract_start_dates_controller.rb
@@ -2,8 +2,6 @@
 
 module Applicants
   class ContractStartDatesController < ApplicationController
-    before_action :check_teacher!
-
     def new
       @contract_start_date = ContractStartDate.new
     end

--- a/app/controllers/applicants/salaried_course_details_controller.rb
+++ b/app/controllers/applicants/salaried_course_details_controller.rb
@@ -15,7 +15,7 @@ module Applicants
         if @salaried_course_detail.eligible?
           session[:eligible_salaried_course] = @salaried_course_detail.eligible_course
 
-          redirect_to(new_applicants_subject_path)
+          redirect_to(new_applicants_contract_start_date_path)
         else
           redirect_to(ineligible_path)
         end

--- a/app/views/applicants/submissions/show.html.erb
+++ b/app/views/applicants/submissions/show.html.erb
@@ -2,31 +2,25 @@
   <main class="govuk-main-wrapper govuk-main-wrapper--l" id="main-content" role="main">
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
+        <div class="govuk-panel govuk-panel--confirmation">
+          <h1 class="govuk-panel__title">
+            Application complete
+          </h1>
+          <div class="govuk-panel__body">
+            Your reference number<br><strong>HDJ2123F</strong>
+          </div>
+        </div>
 
         <h2 class="govuk-heading-m">Thank you</h2>
         <p class="govuk-body">
-          You have successfully submitted your international relocation payment application form and will receive a
-          confirmation email from the Department for Education (Dfe).
+          You have successfully submitted your application form and will receive a confirmation email from the
+          Department for Education (DfE). This will also contain your International Relocation Payment reference number
+          quoted above. Please keep this safe as you will need it if your application is successful.
         </p>
 
         <p class="govuk-body">
-          We will now validate the information you have given us. We will email you if we have any questions.
-        </p>
-
-        <p class="govuk-body">
-          Your international relocation payment (IRP) application reference number is:
-        </p>
-
-        <p class="govuk-body">
-          <strong><%= @application.urn.value %></strong>
-        </p>
-
-        <p class="govuk-body">
-          Keep this safe, as you will need it if your application is successful.
-        </p>
-
-        <p class="govuk-body">
-          We’ll let you know the outcome of your application as soon as we’ve checked your eligibility. If you are
+          We will let you know the outcome of your application as soon as we have validated the information you have
+          given us and checked your eligibility. We will email you if we have any questions about this. If you’re
           eligible, you will be paid around the end of your first term of training or employment.
         </p>
 
@@ -34,9 +28,7 @@
           For help, you can contact us on
           <%= govuk_link_to("IRP.Mailbox@education.gov.uk", "mailto:IRP.Mailbox@education.gov.uk") %>.
         </p>
-
       </div>
-
     </div>
   </main>
 </div>

--- a/spec/features/teacher_route_completing_the_form_spec.rb
+++ b/spec/features/teacher_route_completing_the_form_spec.rb
@@ -50,12 +50,4 @@ describe "teacher route: completing the form" do
   def and_i_complete_the_contract_details_question
     choose_yes
   end
-
-  def and_i_enter_my_contract_start_date
-    fill_in("Day", with: 12)
-    fill_in("Month", with: 7)
-    fill_in("Year", with: 2023)
-
-    click_button("Continue")
-  end
 end

--- a/spec/features/trainee_route_completing_the_form_spec.rb
+++ b/spec/features/trainee_route_completing_the_form_spec.rb
@@ -10,6 +10,7 @@ describe "trainee route: completing the form" do
       when_i_start_the_form
       and_i_complete_application_route_question_with(option: "salaried_trainee")
       and_i_complete_the_trainee_employment_conditions
+      and_i_enter_my_contract_start_date
       and_i_select_my_subject
       and_i_confirm_my_subject_percentage
       and_i_select_my_visa_type

--- a/spec/requests/question_for_contract_start_date_spec.rb
+++ b/spec/requests/question_for_contract_start_date_spec.rb
@@ -18,10 +18,11 @@ module Applicants
           set_user_type("salaried_trainee")
         end
 
-        it "redirects to the start of the process" do
+        it "redirects to the new subject path if it is eligible" do
+          allow(Policies::ContractStartDate).to receive(:eligible?).and_return(true)
           post "/applicants/contract_start_dates", params: valid_params
 
-          expect(response).to redirect_to(new_applicants_application_route_path)
+          expect(response).to redirect_to(new_applicants_subject_path)
         end
       end
 

--- a/spec/support/application_form_steps.rb
+++ b/spec/support/application_form_steps.rb
@@ -77,4 +77,12 @@ RSpec.shared_context "with common application form steps" do
 
     click_button("Continue")
   end
+
+  def and_i_enter_my_contract_start_date
+    fill_in("Day", with: 12)
+    fill_in("Month", with: 7)
+    fill_in("Year", with: 2023)
+
+    click_button("Continue")
+  end
 end


### PR DESCRIPTION
## Trello Card Link

https://trello.com/c/Fl92ae9o/75-trainee-route-start-of-contract-with-the-school

## Description

Add Start Date of contract for Trainees

### Notes

1. We need to add the 3 months validation between the entry date and the start date.

## Screenshots

<img width="750" alt="image" src="https://github.com/DFE-Digital/international-teacher-relocation-payment/assets/134513241/bc9a140d-974b-4526-aa0b-350ff22173f8">
